### PR TITLE
Manifest with bs_const weren't being handled correctly. This fixes it

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import * as AdmZip from 'adm-zip';
 import * as nrc from 'node-run-cmd';
 import * as sinonImport from 'sinon';
+import * as ini from 'ini';
 let sinon = sinonImport.createSandbox();
 
 import { RokuDeploy, RokuDeployOptions, BeforeZipCallbackInfo } from './RokuDeploy';
@@ -953,6 +954,7 @@ describe('index', function () {
             expect(parsedManifest.build_version).to.equal('0');
             expect(parsedManifest.splash_screen_hd).to.equal('pkg:/images/splash_hd.jpg');
             expect(parsedManifest.ui_resolutions).to.equal('hd');
+            expect(parsedManifest.bs_const).to.equal('IS_DEV_BUILD=false');
         });
 
         it('Throws our error message for a missing file', async () => {
@@ -964,6 +966,43 @@ describe('index', function () {
                 return;
             }
             assert.fail('Exception should have been thrown');
+        });
+    });
+
+    describe('stringifyManifest', () => {
+        it('correctly converts back to a valid manifest with bs_const', async () => {
+            let rootProjectDir = path.resolve(options.rootDir);
+            let manifestPath = path.join(rootProjectDir, 'manifest');
+
+            let inputParsedManifest = await rokuDeploy.parseManifest(manifestPath);
+            let outputStringifiedManifest = rokuDeploy.stringifyManifest(inputParsedManifest);
+            let outputParsedManifest = ini.parse(outputStringifiedManifest);
+
+            expect(outputParsedManifest.title).to.equal(inputParsedManifest.title);
+            expect(outputParsedManifest.major_version).to.equal(inputParsedManifest.major_version);
+            expect(outputParsedManifest.minor_version).to.equal(inputParsedManifest.minor_version);
+            expect(outputParsedManifest.build_version).to.equal(inputParsedManifest.build_version);
+            expect(outputParsedManifest.splash_screen_hd).to.equal(inputParsedManifest.splash_screen_hd);
+            expect(outputParsedManifest.ui_resolutions).to.equal(inputParsedManifest.ui_resolutions);
+            expect(outputParsedManifest.bs_const).to.equal(inputParsedManifest.bs_const);
+        });
+
+        it('correctly converts back to a valid manifest without bs_const', async () => {
+            let rootProjectDir = path.resolve(options.rootDir);
+            let manifestPath = path.join(rootProjectDir, 'manifest');
+
+            let inputParsedManifest = await rokuDeploy.parseManifest(manifestPath);
+            delete inputParsedManifest.bs_const
+            let outputStringifiedManifest = rokuDeploy.stringifyManifest(inputParsedManifest);
+            let outputParsedManifest = ini.parse(outputStringifiedManifest);
+
+            expect(outputParsedManifest.title).to.equal(inputParsedManifest.title);
+            expect(outputParsedManifest.major_version).to.equal(inputParsedManifest.major_version);
+            expect(outputParsedManifest.minor_version).to.equal(inputParsedManifest.minor_version);
+            expect(outputParsedManifest.build_version).to.equal(inputParsedManifest.build_version);
+            expect(outputParsedManifest.splash_screen_hd).to.equal(inputParsedManifest.splash_screen_hd);
+            expect(outputParsedManifest.ui_resolutions).to.equal(inputParsedManifest.ui_resolutions);
+            expect(outputParsedManifest.bs_const).to.equal(inputParsedManifest.bs_const);
         });
     });
 

--- a/testProject/manifest
+++ b/testProject/manifest
@@ -4,3 +4,4 @@ minor_version=0
 build_version=0
 splash_screen_hd=pkg:/images/splash_hd.jpg
 ui_resolutions=hd
+bs_const=IS_DEV_BUILD=false


### PR DESCRIPTION
bs_const uses equal signs in the right hand side which ini then adds quotes around the whole thing. It doesn't seem like a fix will be available soon (https://github.com/npm/ini/issues/57) so we remove it before stringifying and add it back in afterwards to get around this.