### PR TITLE
Fix `zipFolder` bug that wasn't properly handling absolute stagingDir path

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -809,6 +809,25 @@ describe('RokuDeploy', () => {
             // whereas the old `${stagingDir}/${absoluteDest}` would produce a doubled path
             expect(copyPaths[0].dest).to.equal(absoluteDest);
         });
+
+        it('copies to stagingDir root when dest is undefined', async () => {
+            const copyPaths = [] as Array<{ src: string; dest: string }>;
+            sinon.stub(rokuDeploy.fsExtra, 'ensureDir').returns(Promise.resolve() as any);
+            sinon.stub(rokuDeploy.fsExtra as any, 'copy').callsFake((src, dest) => {
+                copyPaths.push({ src: src as string, dest: dest as string });
+                return Promise.resolve();
+            });
+            sinon.stub(rokuDeploy, 'getFilePaths').returns(
+                Promise.resolve([{
+                    src: s`${rootDir}/source/main.brs`,
+                    dest: undefined
+                }])
+            );
+
+            await rokuDeploy['copyToStaging']([], stagingDir, rootDir);
+
+            expect(copyPaths[0].dest).to.equal(s`${stagingDir}`);
+        });
     });
 
     describe('zipPackage', () => {

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -761,10 +761,10 @@ describe('RokuDeploy', () => {
                 Promise.resolve([
                     {
                         src: s`${rootDir}/source/main.brs`,
-                        dest: '/source/main.brs'
+                        dest: 'source/main.brs'
                     }, {
                         src: s`${rootDir}/components/a/b/c/comp1.xml`,
-                        dest: '/components/a/b/c/comp1.xml'
+                        dest: 'components/a/b/c/comp1.xml'
                     }
                 ])
             );
@@ -785,6 +785,29 @@ describe('RokuDeploy', () => {
                     dest: s`${stagingDir}/components/a/b/c/comp1.xml`
                 }
             ]);
+        });
+
+        it('does not double-up the path when dest is absolute', async () => {
+            const copyPaths = [] as Array<{ src: string; dest: string }>;
+            sinon.stub(rokuDeploy.fsExtra, 'ensureDir').returns(Promise.resolve() as any);
+            sinon.stub(rokuDeploy.fsExtra as any, 'copy').callsFake((src, dest) => {
+                copyPaths.push({ src: src as string, dest: dest as string });
+                return Promise.resolve();
+            });
+
+            const absoluteDest = s`${stagingDir}/source/main.brs`;
+            sinon.stub(rokuDeploy, 'getFilePaths').returns(
+                Promise.resolve([{
+                    src: s`${rootDir}/source/main.brs`,
+                    dest: absoluteDest
+                }])
+            );
+
+            await rokuDeploy['copyToStaging']([], stagingDir, rootDir);
+
+            // path.resolve(stagingDir, absoluteDest) returns absoluteDest unchanged,
+            // whereas the old `${stagingDir}/${absoluteDest}` would produce a doubled path
+            expect(copyPaths[0].dest).to.equal(absoluteDest);
         });
     });
 
@@ -3363,6 +3386,20 @@ describe('RokuDeploy', () => {
             expect(
                 rokuDeploy['computeFileDestPath'](s`${rootDir}/source/main.brs`, { src: s`source/main.brs` } as any, rootDir)
             ).to.eql(s`source/main.brs`);
+        });
+    });
+
+    describe('zipFolder absolute dest', () => {
+        it('does not create absolute-path entries in the zip when dest is absolute', async () => {
+            writeFiles(stagingDir, ['source/main.brs']);
+            const outputZipPath = s`${tempDir}/output.zip`;
+            await rokuDeploy.zipFolder(stagingDir, outputZipPath, null, [{
+                src: s`${stagingDir}/source/main.brs`,
+                dest: s`${stagingDir}/source/main.brs`
+            }]);
+            const zip = await JSZip.loadAsync(fsExtra.readFileSync(outputZipPath) as any);
+            const zipPaths = Object.keys(zip.files);
+            expect(zipPaths.every(p => !path.isAbsolute(p))).to.be.true;
         });
     });
 

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -3389,6 +3389,44 @@ describe('RokuDeploy', () => {
         });
     });
 
+    describe('zipFolder {src;dest} entries', () => {
+        it('places file at relative dest path', async () => {
+            writeFiles(stagingDir, ['source/main.brs']);
+            const outputZipPath = s`${tempDir}/output.zip`;
+            await rokuDeploy.zipFolder(stagingDir, outputZipPath, null, [{
+                src: s`${stagingDir}/source/main.brs`,
+                dest: 'source/main.brs'
+            }]);
+            const zip = await JSZip.loadAsync(fsExtra.readFileSync(outputZipPath) as any);
+            expect(zip.file('source/main.brs')).to.exist;
+        });
+
+        it('places file at redirected relative dest path', async () => {
+            writeFiles(stagingDir, ['source/main.brs']);
+            const outputZipPath = s`${tempDir}/output.zip`;
+            await rokuDeploy.zipFolder(stagingDir, outputZipPath, null, [{
+                src: s`${stagingDir}/source/main.brs`,
+                dest: 'out/renamed.brs'
+            }]);
+            const zip = await JSZip.loadAsync(fsExtra.readFileSync(outputZipPath) as any);
+            expect(zip.file('out/renamed.brs')).to.exist;
+            expect(zip.file('source/main.brs')).not.to.exist;
+        });
+
+        it('places file from outside srcFolder at specified dest', async () => {
+            const otherDir = s`${tempDir}/other`;
+            writeFiles(otherDir, ['lib.brs']);
+            writeFiles(stagingDir, ['source/main.brs']);
+            const outputZipPath = s`${tempDir}/output.zip`;
+            await rokuDeploy.zipFolder(stagingDir, outputZipPath, null, [{
+                src: s`${otherDir}/lib.brs`,
+                dest: 'source/lib.brs'
+            }]);
+            const zip = await JSZip.loadAsync(fsExtra.readFileSync(outputZipPath) as any);
+            expect(zip.file('source/lib.brs')).to.exist;
+        });
+    });
+
     describe('zipFolder absolute dest', () => {
         it('does not create absolute-path entries in the zip when dest is absolute', async () => {
             writeFiles(stagingDir, ['source/main.brs']);

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -357,7 +357,9 @@ export class RokuDeploy {
         let fileObjects = await this.getFilePaths(files, rootDir);
         //copy all of the files
         await Promise.all(fileObjects.map(async (fileObject) => {
-            let destFilePath = util.standardizePath(`${stagingPath}/${fileObject.dest}`);
+            let destFilePath = util.standardizePath(
+                path.resolve(stagingPath, fileObject.dest ?? '')
+            );
 
             //make sure the containing folder exists
             await this.fsExtra.ensureDir(path.dirname(destFilePath));
@@ -1354,7 +1356,7 @@ export class RokuDeploy {
                 if (ext === '.jpg' || ext === '.png' || ext === '.jpeg') {
                     compression = 'STORE';
                 }
-                zip.file(file.dest.replace(/[\\/]/g, '/'), data as any, {
+                zip.file(path.relative(srcFolder, path.resolve(srcFolder, file.dest)).replace(/[\\/]/g, '/'), data as any, {
                     compression: compression
                 });
             });

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -238,6 +238,40 @@ describe('util', () => {
             //shouldn't crash
             util['filterPaths']('*', [], '', 2);
         });
+
+        it('does not double-up the path when the negation pattern is absolute', () => {
+            const absoluteFile = s`${tempDir}/source/main.brs`;
+            const filesByIndex = [[absoluteFile]];
+            // pattern is an absolute negation like `!C:/tempDir/source/main.brs`
+            util['filterPaths'](`!${absoluteFile}`, filesByIndex, s`${tempDir}`, 0);
+            // file should be filtered out — if path was doubled it would never match and the file would remain
+            expect(filesByIndex[0]).to.eql([]);
+        });
+    });
+
+    describe('globAllByIndex absolute patterns', () => {
+        function writeFiles(filePaths: string[], cwd = tempDir) {
+            for (const filePath of filePaths) {
+                fsExtra.outputFileSync(path.resolve(cwd, filePath), '');
+            }
+        }
+
+        it('does not double-up path when pattern is absolute', async () => {
+            writeFiles(['source/main.brs']);
+            const absolutePattern = s`${tempDir}/source/main.brs`;
+            const results = await util.globAllByIndex([absolutePattern], tempDir);
+            expect(results[0]?.map(x => s(x))).to.eql([absolutePattern]);
+        });
+
+        it('correctly filters files when negation pattern is absolute', async () => {
+            writeFiles(['source/main.brs', 'source/lib.brs']);
+            const results = await util.globAllByIndex([
+                '**/*.brs',
+                `!${s`${tempDir}/source/main.brs`}`
+            ], tempDir);
+            // main.brs should be filtered out; lib.brs should remain
+            expect(results[0]?.map(x => s(x)).sort()).to.eql([s`${tempDir}/source/lib.brs`]);
+        });
     });
 
     describe('dnsLookup', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -179,7 +179,7 @@ export class Util {
      */
     private filterPaths(pattern: string, filesByIndex: string[][], cwd: string, stopIndex: number) {
         //move the ! to the start of the string to negate the absolute path, replace windows slashes with unix ones
-        let negatedPatternAbsolute = '!' + path.posix.join(cwd, pattern.replace(/^!/, ''));
+        let negatedPatternAbsolute = '!' + path.resolve(cwd, pattern.replace(/^!/, '')).replace(/\\/g, '/');
         let filter = micromatch.matcher(negatedPatternAbsolute);
         for (let i = 0; i <= stopIndex; i++) {
             if (filesByIndex[i]) {


### PR DESCRIPTION
Fixes several issues related to an absolute path being incorrectly concatenated with rootDir or outDir rather than leveraging `path.resolve()` 