### PR TITLE
chore: drop undici, use native fetch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: "16.20.2"
+          node-version: "18.20.4"
           architecture: 'x64' # fix for macos-latest
       - run: cd src && cd .. #trying to fix "ENOENT: no such file or directory, uv_cwd" error
       - run: npm ci

--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: "16.20.2"
+          node-version: "18.20.4"
       # Get a bot token so the bot's name shows up on all our actions
       - name: Get Token From roku-ci-token Application
         uses: tibdex/github-app-token@v1

--- a/.github/workflows/make-release-artifacts.yml
+++ b/.github/workflows/make-release-artifacts.yml
@@ -24,7 +24,7 @@ jobs:
     uses: rokucommunity/workflows/.github/workflows/make-release-artifacts.yml@master
     with:
       branch: ${{ github.event.inputs.tag || github.event.pull_request.head.ref }}
-      node-version: "16.20.2"
+      node-version: "18.20.4"
       artifact-paths: "./*.tgz" # "*.vsix"
       force: ${{ github.event.inputs.force == 'true' }}
     secrets: inherit

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
                 "postman-request": "^2.88.1-postman.40",
                 "semver": "^7.7.3",
                 "temp-dir": "^2.0.0",
-                "undici": "^5.29.0",
                 "xml2js": "^0.5.0"
             },
             "bin": {
@@ -441,15 +440,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 4"
-            }
-        },
-        "node_modules/@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -4923,18 +4913,6 @@
                 "coveralls-next": "^4.2.1"
             }
         },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
-            }
-        },
         "node_modules/undici-types": {
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -5572,11 +5550,6 @@
                     "dev": true
                 }
             }
-        },
-        "@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
         },
         "@humanwhocodes/config-array": {
             "version": "0.6.0",
@@ -8911,14 +8884,6 @@
             "dev": true,
             "requires": {
                 "coveralls-next": "^4.2.1"
-            }
-        },
-        "undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "requires": {
-                "@fastify/busboy": "^2.0.0"
             }
         },
         "undici-types": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
         "postman-request": "^2.88.1-postman.40",
         "semver": "^7.7.3",
         "temp-dir": "^2.0.0",
-        "undici": "^5.29.0",
         "xml2js": "^0.5.0"
     },
     "devDependencies": {

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -10,8 +10,7 @@ import * as child_process from 'child_process';
 import * as glob from 'glob';
 import type { BeforeZipCallbackInfo } from './RokuDeploy';
 import { RokuDeploy } from './RokuDeploy';
-import { buildDigestAuthorization, parseDigestChallenge } from './fetch';
-import * as undici from 'undici';
+import { buildDigestAuthorization, httpClient, parseDigestChallenge } from './fetch';
 import * as errors from './Errors';
 import { util, standardizePath as s } from './util';
 import type { FileEntry, RokuDeployOptions } from './RokuDeployOptions';
@@ -4691,7 +4690,7 @@ describe('RokuDeploy', () => {
         }
 
         it('returns true when the device accepts the credentials', async () => {
-            const fetchStub = sinon.stub(undici, 'fetch')
+            const fetchStub = sinon.stub(httpClient, 'fetch')
                 .onFirstCall().resolves(fakeResponse(401, { 'www-authenticate': CHALLENGE_HEADER }))
                 .onSecondCall().resolves(fakeResponse(200));
 
@@ -4708,7 +4707,7 @@ describe('RokuDeploy', () => {
         });
 
         it('returns false when the authenticated retry is rejected', async () => {
-            sinon.stub(undici, 'fetch')
+            sinon.stub(httpClient, 'fetch')
                 .onFirstCall().resolves(fakeResponse(401, { 'www-authenticate': CHALLENGE_HEADER }))
                 .onSecondCall().resolves(fakeResponse(401, { 'www-authenticate': CHALLENGE_HEADER }));
 
@@ -4718,7 +4717,7 @@ describe('RokuDeploy', () => {
         });
 
         it('throws DeviceUnreachableError when the first request throws', async () => {
-            sinon.stub(undici, 'fetch').rejects(new Error('ECONNREFUSED'));
+            sinon.stub(httpClient, 'fetch').rejects(new Error('ECONNREFUSED'));
 
             let thrown: unknown;
             try {
@@ -4731,7 +4730,7 @@ describe('RokuDeploy', () => {
         });
 
         it('throws InvalidDeviceResponseCodeError on an unexpected status (e.g. 500)', async () => {
-            sinon.stub(undici, 'fetch').resolves(fakeResponse(500));
+            sinon.stub(httpClient, 'fetch').resolves(fakeResponse(500));
 
             let thrown: unknown;
             try {
@@ -4744,7 +4743,7 @@ describe('RokuDeploy', () => {
         });
 
         it('returns false when a 401 has no WWW-Authenticate header', async () => {
-            sinon.stub(undici, 'fetch').resolves(fakeResponse(401));
+            sinon.stub(httpClient, 'fetch').resolves(fakeResponse(401));
 
             const result = await rokuDeploy.validateDeveloperPassword({ host: '1.2.3.4', password: 'aaaa' });
 
@@ -4752,7 +4751,7 @@ describe('RokuDeploy', () => {
         });
 
         it('uses default port 80, username rokudev, and plugin_install path', async () => {
-            const fetchStub = sinon.stub(undici, 'fetch')
+            const fetchStub = sinon.stub(httpClient, 'fetch')
                 .onFirstCall().resolves(fakeResponse(401, { 'www-authenticate': CHALLENGE_HEADER }))
                 .onSecondCall().resolves(fakeResponse(200));
 
@@ -4764,7 +4763,7 @@ describe('RokuDeploy', () => {
         });
 
         it('honors custom username and port', async () => {
-            const fetchStub = sinon.stub(undici, 'fetch')
+            const fetchStub = sinon.stub(httpClient, 'fetch')
                 .onFirstCall().resolves(fakeResponse(401, { 'www-authenticate': CHALLENGE_HEADER }))
                 .onSecondCall().resolves(fakeResponse(200));
 
@@ -4781,7 +4780,7 @@ describe('RokuDeploy', () => {
         });
 
         it('aborts the request when the timeout elapses', async () => {
-            sinon.stub(undici, 'fetch').callsFake((_url, init?: any) => {
+            sinon.stub(httpClient, 'fetch').callsFake((_url, init?: any) => {
                 return new Promise((resolve, reject) => {
                     init?.signal?.addEventListener('abort', () => {
                         const err: any = new Error('aborted');
@@ -4805,7 +4804,7 @@ describe('RokuDeploy', () => {
         });
 
         it('stringifies non-Error fetch rejections', async () => {
-            sinon.stub(undici, 'fetch').callsFake(() => Promise.reject('boom'));
+            sinon.stub(httpClient, 'fetch').callsFake(() => Promise.reject('boom'));
 
             let thrown: unknown;
             try {

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -20,7 +20,6 @@ import * as lodash from 'lodash';
 import type { DeviceInfo, DeviceInfoRaw } from './DeviceInfo';
 import * as semver from 'semver';
 import { fetchWithDigest } from './fetch';
-import type * as undici from 'undici';
 
 export class RokuDeploy {
 
@@ -1231,7 +1230,7 @@ export class RokuDeploy {
         const timeout = options.timeout ?? 3000;
         const url = `http://${options.host}:${port}/plugin_install`;
 
-        let response: undici.Response;
+        let response: Response;
         try {
             response = await fetchWithDigest(url, {
                 method: 'HEAD',

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,5 +1,11 @@
 import * as crypto from 'crypto';
-import * as undici from 'undici';
+
+// Module seam for `fetch` so tests can stub it. On Node 18, `fetch` is a lazy
+// getter on `globalThis` (not an own property), so `sinon.stub(globalThis, 'fetch')`
+// fails there — routing calls through this object gives a regular, stubbable export.
+export const httpClient = {
+    fetch: globalThis.fetch.bind(globalThis)
+};
 
 /**
  * Issue an HTTP request with digest authentication.
@@ -10,8 +16,8 @@ import * as undici from 'undici';
  */
 export async function fetchWithDigest(
     url: string,
-    init: undici.RequestInit & { method: string; username: string; password: string; timeout: number }
-): Promise<undici.Response> {
+    init: RequestInit & { method: string; username: string; password: string; timeout: number }
+): Promise<Response> {
     const { username, password, timeout, ...fetchInit } = init;
     const method = fetchInit.method.toUpperCase();
 
@@ -41,10 +47,10 @@ export async function fetchWithDigest(
     }, timeout);
 }
 
-function fetchWithTimeout(url: string, init: undici.RequestInit, timeout: number): Promise<undici.Response> {
+function fetchWithTimeout(url: string, init: RequestInit, timeout: number): Promise<Response> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeout);
-    return undici.fetch(url, { ...init, signal: controller.signal })
+    return httpClient.fetch(url, { ...init, signal: controller.signal })
         .finally(() => clearTimeout(timer));
 }
 


### PR DESCRIPTION
## Summary
- Drop the `undici` dependency and route `fetchWithDigest` through the native `fetch` global.
- Add a small `httpClient` module seam in `src/fetch.ts` so tests can stub `fetch` without touching `globalThis.fetch` (which is a lazy getter on Node 18 and therefore not sinon-stubbable).
- Bump the pinned Node version in the build, create-package, and release-artifact workflows from `16.20.2` to `18.20.4`.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` — 361 passing, 100% coverage
- [x] CI green on Node 18.20.4 across ubuntu / macos / windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)