### PR TITLE
Fix crash when loading roku-deploy on node < 18

### DIFF
--- a/src/fetch.spec.ts
+++ b/src/fetch.spec.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+const sinon = createSandbox();
+
+describe('fetch module', () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('does not crash when globalThis.fetch is undefined (pre-Node-18)', () => {
+        // Simulate a Node version that has no native fetch
+        const original = (globalThis as any).fetch;
+        delete (globalThis as any).fetch;
+        try {
+            // Re-require so the module-level initializer runs without fetch
+            delete require.cache[require.resolve('./fetch')];
+            expect(() => require('./fetch')).not.to.throw();
+            const { httpClient } = require('./fetch');
+            expect(httpClient.fetch).to.be.undefined;
+        } finally {
+            (globalThis as any).fetch = original;
+            delete require.cache[require.resolve('./fetch')];
+        }
+    });
+
+    it('binds globalThis.fetch when it is available', () => {
+        const fakeFetch = sinon.stub().resolves(new Response());
+        const original = (globalThis as any).fetch;
+        (globalThis as any).fetch = fakeFetch;
+        try {
+            delete require.cache[require.resolve('./fetch')];
+            const { httpClient } = require('./fetch');
+            expect(httpClient.fetch).to.be.a('function');
+        } finally {
+            (globalThis as any).fetch = original;
+            delete require.cache[require.resolve('./fetch')];
+        }
+    });
+});

--- a/src/fetch.spec.ts
+++ b/src/fetch.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 import { expect } from 'chai';
 import { createSandbox } from 'sinon';
 const sinon = createSandbox();

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -4,7 +4,7 @@ import * as crypto from 'crypto';
 // getter on `globalThis` (not an own property), so `sinon.stub(globalThis, 'fetch')`
 // fails there — routing calls through this object gives a regular, stubbable export.
 export const httpClient = {
-    fetch: globalThis.fetch.bind(globalThis)
+    fetch: globalThis.fetch?.bind(globalThis)
 };
 
 /**


### PR DESCRIPTION
#254 dropped `undici` in favor of native fetch, which requires node 18+. We thought we had guarded against that being a requirement, but had a bug where binding to globalThis.fetch was crashing on node < 18. Now we'll properly return `undefined` instead of crashing when `fetch` isn't available.