### PR TITLE
Add `autoLaunch` option to control `dev_autolaunch` on sideload

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -1354,6 +1354,27 @@ describe('RokuDeploy', () => {
             });
         });
 
+        it('sets dev_autolaunch to 0 when autoLaunch is false', async () => {
+            options.autoLaunch = false;
+            const stub = mockDoPostRequest();
+
+            const result = await rokuDeploy.publish(options);
+            expect(result.message).to.equal('Successful deploy');
+            expect(stub.getCall(0).args[0].formData.dev_autolaunch).to.eql('0');
+        });
+
+        it('omits dev_autolaunch when autoLaunch is not false', async () => {
+            const stub = mockDoPostRequest();
+
+            delete options.autoLaunch;
+            await rokuDeploy.publish(options);
+            expect(stub.getCall(0).args[0].formData).to.not.haveOwnProperty('dev_autolaunch');
+
+            options.autoLaunch = true;
+            await rokuDeploy.publish(options);
+            expect(stub.getCall(1).args[0].formData).to.not.haveOwnProperty('dev_autolaunch');
+        });
+
         it('does not set appType if not explicitly defined', async () => {
             delete options.appType;
             const stub = mockDoPostRequest();

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -493,6 +493,12 @@ export class RokuDeploy {
                 requestOptions.formData.remotedebug_connect_early = '1';
             }
 
+            //disable auto-launching the channel after install if explicitly opted out
+            if (options.autoLaunch === false) {
+                // eslint-disable-next-line camelcase
+                requestOptions.formData.dev_autolaunch = '0';
+            }
+
             //apply any supplied formData overrides
             for (const key in options.packageUploadOverrides?.formData ?? {}) {
                 const value = options.packageUploadOverrides.formData[key];

--- a/src/RokuDeployOptions.ts
+++ b/src/RokuDeployOptions.ts
@@ -100,6 +100,12 @@ export interface RokuDeployOptions {
     remoteDebugConnectEarly?: boolean;
 
     /**
+     * When publishing a sideloaded channel, set this to `false` to prevent the Roku device from auto-launching the channel after install.
+     * When omitted (the default), the device's normal auto-launch behavior is used.
+     */
+    autoLaunch?: boolean;
+
+    /**
      * The port used to send remote control commands (like home press, back, etc.). Defaults to 8060.
      * This is mainly useful for things like emulators that use alternate ports,
      * or when sending commands through some type of port forwarding.


### PR DESCRIPTION
## Summary
- Adds a new `autoLaunch?: boolean` option to `RokuDeployOptions`. When set to `false`, the publish call sends `dev_autolaunch=0` in the sideload form data so the device installs the channel without launching it.
- Omitting the option preserves the device's default auto-launch behavior — no form field is sent.