### PR TITLE
Security Audit workflow

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    #nightly at 00:00 UTC
+    - cron: '0 0 * * *'
 
 jobs:
   audit:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,17 @@
+name: Security Audit
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: "18.20.4"
+      - run: npm ci
+      - run: npm run audit

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -5,8 +5,8 @@ on:
       - master
   pull_request:
   schedule:
-    #nightly at 00:00 UTC
-    - cron: '0 0 * * *'
+    #nightly at 06:00 UTC (1am EST / 2am EDT)
+    - cron: '0 6 * * *'
 
 jobs:
   audit:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Publish Roku projects to a Roku device by using Node.js.
 
 [![build status](https://img.shields.io/github/actions/workflow/status/rokucommunity/roku-deploy/build.yml?branch=master)](https://github.com/rokucommunity/roku-deploy/actions?query=branch%3Amaster+workflow%3Abuild)
+[![Security Audit](https://img.shields.io/github/actions/workflow/status/rokucommunity/roku-deploy/security-audit.yml?branch=master)](https://github.com/rokucommunity/roku-deploy/actions/workflows/security-audit.yml)
 [![coverage status](https://img.shields.io/coveralls/github/rokucommunity/roku-deploy?logo=coveralls)](https://coveralls.io/github/rokucommunity/roku-deploy?branch=master)
 [![monthly downloads](https://img.shields.io/npm/dm/roku-deploy.svg?sanitize=true&logo=npm&logoColor=)](https://npmcharts.com/compare/roku-deploy?minimal=true)
 [![npm version](https://img.shields.io/npm/v/roku-deploy.svg?logo=npm)](https://www.npmjs.com/package/roku-deploy)


### PR DESCRIPTION
Adds a dedicated `Security Audit` GitHub Actions workflow that runs `npm run audit` on PRs and master pushes. The job is single-OS (ubuntu-latest, node 18.20.4) so the status check is fast and self-contained.
