### PR TITLE
Add a files option to the zip command

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -727,6 +727,60 @@ describe('RokuDeploy', () => {
             expect(err.message.startsWith('Cannot zip'), `Unexpected error message: "${err.message}"`).to.be.true;
         });
 
+        it('should zip only files matching the files array filter', async () => {
+            fsExtra.outputFileSync(s`${rootDir}/manifest`, 'title=Test');
+            fsExtra.outputFileSync(s`${rootDir}/source/main.brs`, 'sub main()\nend sub');
+            fsExtra.outputFileSync(s`${rootDir}/components/comp.xml`, '<component />');
+            fsExtra.outputFileSync(s`${rootDir}/extra/stuff.txt`, 'should not be included');
+
+            await rokuDeploy.zip({
+                dir: rootDir,
+                files: ['manifest', 'source/**/*'],
+                out: `${outDir}/roku-deploy.zip`
+            });
+
+            const zip = new JSZip();
+            const zipContents = await zip.loadAsync(fsExtra.readFileSync(`${outDir}/roku-deploy.zip`));
+            expect(zipContents.files['manifest']).to.exist;
+            expect(zipContents.files['source/main.brs']).to.exist;
+            expect(zipContents.files['components/comp.xml']).to.not.exist;
+            expect(zipContents.files['extra/stuff.txt']).to.not.exist;
+        });
+
+        it('should throw error when files filter excludes manifest', async () => {
+            fsExtra.outputFileSync(s`${rootDir}/manifest`, 'title=Test');
+            fsExtra.outputFileSync(s`${rootDir}/source/main.brs`, 'sub main()\nend sub');
+
+            let err: Error | undefined;
+            try {
+                await rokuDeploy.zip({
+                    dir: rootDir,
+                    files: ['source/**/*'],
+                    out: `${outDir}/roku-deploy.zip`
+                });
+            } catch (e) {
+                err = e as Error;
+            }
+            expect(err?.message).to.include('missing manifest');
+        });
+
+        it('should zip all files when files array is not provided', async () => {
+            fsExtra.outputFileSync(s`${rootDir}/manifest`, 'title=Test');
+            fsExtra.outputFileSync(s`${rootDir}/source/main.brs`, 'sub main()\nend sub');
+            fsExtra.outputFileSync(s`${rootDir}/components/comp.xml`, '<component />');
+
+            await rokuDeploy.zip({
+                dir: rootDir,
+                out: `${outDir}/roku-deploy.zip`
+            });
+
+            const zip = new JSZip();
+            const zipContents = await zip.loadAsync(fsExtra.readFileSync(`${outDir}/roku-deploy.zip`));
+            expect(zipContents.files['manifest']).to.exist;
+            expect(zipContents.files['source/main.brs']).to.exist;
+            expect(zipContents.files['components/comp.xml']).to.exist;
+        });
+
     });
 
     it('runs via the command line using the rokudeploy.json file', function test() {

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -82,13 +82,14 @@ export class RokuDeploy {
      * @param options
      */
     public async zip(options: ZipOptions) {
-        logger.info('Beginning to zip folder');
+        logger.info('Beginning to zip');
         const cwd = options.cwd ?? process.cwd();
 
-        // Resolve source directory - dir is required
+        // dir is required
         if (!options.dir) {
-            throw new Error('dir is required for zip');
+            throw new Error('"dir" is required for zip');
         }
+
         const dir = path.resolve(cwd, options.dir);
 
         // Resolve output zip path - use 'out' if provided, otherwise default
@@ -101,13 +102,17 @@ export class RokuDeploy {
             out += '.zip';
         }
 
-        //ensure the manifest file exists in the folder to be zipped
-        if (!await util.fileExistsCaseInsensitive(`${dir}/manifest`)) {
+        // Get files to include - use provided files array or default to everything
+        const files = options.files ?? ['**/*'];
+
+        // Check that manifest will be included
+        const filePaths = await this.getFilePaths({ files: files, rootDir: dir });
+        const hasManifest = filePaths.some(f => f.dest.toLowerCase() === 'manifest');
+        if (!hasManifest) {
             throw new Error(`Cannot zip package: missing manifest file in "${dir}"`);
         }
 
-        //create a zip of the folder
-        await this.makeZip(dir, out);
+        await this.makeZip(dir, out, files);
         logger.info('Zip created at:', out);
     }
 
@@ -1298,9 +1303,14 @@ export interface StageOptions {
 
 export interface ZipOptions {
     /**
-     * The directory to be zipped
+     * The directory containing the files to be zipped
      */
-    dir?: string;
+    dir: string;
+    /**
+     * An optional array of file patterns to include in the zip.
+     * If not provided, defaults to all files (`**\/*`).
+     */
+    files?: FileEntry[];
     /**
      * The output zip file path (e.g., './out/roku-deploy.zip')
      */

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -20,12 +20,14 @@ function execSync(command: string) {
     process.stdout.write(output);
     return output;
 }
-describe('cli', () => {
-    before(function build() {
-        //all cli tests spawn `node dist/cli.js` via execSync, which can exceed the default 2s timeout
-        this.timeout(60_000);
+describe('cli', function cli() {
+    //all cli tests spawn `node dist/cli.js` via execSync, which can exceed the default 2s timeout
+    this.timeout(60_000);
+
+    before(() => {
         execSync('npm run build');
     });
+
     beforeEach(() => {
         fsExtra.emptyDirSync(tempDir);
         //most tests depend on a manifest file existing, so write an empty one

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -164,10 +164,11 @@ void yargs
         return new GetDevIdCommand().run(args);
     })
 
-    .command('zip', 'Given a path to a folder, zip up that folder and all of its contents', (builder) => {
+    .command('zip', 'Zip a folder into a package', (builder) => {
         return builder
-            .option('dir', { type: 'string', description: 'The folder to be zipped', demandOption: false })
-            .option('out', { type: 'string', description: 'the path to the zip file that will be created, relative to cwd', demandOption: false, alias: 'outZip' })
+            .option('dir', { type: 'string', description: 'The folder to be zipped', demandOption: true })
+            .option('files', { type: 'array', description: 'Optional file patterns to filter which files are included (defaults to all files)', demandOption: false })
+            .option('out', { type: 'string', description: 'The path to the zip file that will be created, relative to cwd', demandOption: false, alias: 'outZip' })
             .option('cwd', { type: 'string', description: 'The current working directory to use for relative paths', demandOption: false });
     }, (args: any) => {
         return new ZipCommand().run(args);


### PR DESCRIPTION
Allows filtering which files are included when zipping a directory. Defaults to all files if not specified.                                               
                                                                               
  ```
// Zip everything in the directory (existing behavior)                       
  await rokuDeploy.zip({                                                       
      dir: './staging',                                                        
      out: './out.zip'                   
  });
```
                                                           
```
  // Zip only specific files
  await rokuDeploy.zip({
      dir: './src',
      files: ['source/**/*', 'components/**/*', 'manifest'],
      out: './out.zip'
  });
```

  CLI:
```
  npx roku-deploy zip --dir ./src --files "source/**/*" "manifest" --out app.zip
```