### PR TITLE
Inline lodash.camelCase and temp-dir into util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,9 @@
                 "is-glob": "^4.0.3",
                 "jsonc-parser": "^2.3.0",
                 "jszip": "^3.6.0",
-                "lodash": "^4.17.21",
                 "micromatch": "^4.0.4",
                 "postman-request": "^2.88.1-postman.48",
                 "semver": "^7.7.3",
-                "temp-dir": "^2.0.0",
                 "xml2js": "^0.5.0"
             },
             "bin": {
@@ -30,7 +28,6 @@
                 "@types/chai": "^4.2.22",
                 "@types/fs-extra": "^5.0.1",
                 "@types/is-glob": "^4.0.2",
-                "@types/lodash": "^4.14.200",
                 "@types/micromatch": "^4.0.2",
                 "@types/mocha": "^10.0.0",
                 "@types/node": "^18.19.0",
@@ -765,12 +762,6 @@
             "version": "7.0.9",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
             "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
-            "dev": true
-        },
-        "node_modules/@types/lodash": {
-            "version": "4.14.200",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-            "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
             "dev": true
         },
         "node_modules/@types/micromatch": {
@@ -3273,11 +3264,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/lodash": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
-        },
         "node_modules/lodash.flattendeep": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -4839,14 +4825,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/temp-dir": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-            "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/test-exclude": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -5921,12 +5899,6 @@
             "version": "7.0.9",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
             "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
-            "dev": true
-        },
-        "@types/lodash": {
-            "version": "4.14.200",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-            "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
             "dev": true
         },
         "@types/micromatch": {
@@ -7739,11 +7711,6 @@
                 "p-locate": "^5.0.0"
             }
         },
-        "lodash": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
-        },
         "lodash.flattendeep": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -8888,11 +8855,6 @@
             "requires": {
                 "has-flag": "^3.0.0"
             }
-        },
-        "temp-dir": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-            "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg=="
         },
         "test-exclude": {
             "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -26,18 +26,15 @@
         "is-glob": "^4.0.3",
         "jsonc-parser": "^2.3.0",
         "jszip": "^3.6.0",
-        "lodash": "^4.17.21",
         "micromatch": "^4.0.4",
         "postman-request": "^2.88.1-postman.48",
         "semver": "^7.7.3",
-        "temp-dir": "^2.0.0",
         "xml2js": "^0.5.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.22",
         "@types/fs-extra": "^5.0.1",
         "@types/is-glob": "^4.0.2",
-        "@types/lodash": "^4.14.200",
         "@types/micromatch": "^4.0.2",
         "@types/mocha": "^10.0.0",
         "@types/node": "^18.19.0",

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -13,8 +13,6 @@ import { parse as parseJsonc, printParseErrorCode } from 'jsonc-parser';
 import { util } from './util';
 import type { RokuDeployOptions, FileEntry } from './RokuDeployOptions';
 import { Logger, LogLevel } from './Logger';
-import * as tempDir from 'temp-dir';
-import * as lodash from 'lodash';
 import type { DeviceInfo, DeviceInfoRaw } from './DeviceInfo';
 import * as semver from 'semver';
 import { fetchWithDigest } from './fetch';
@@ -31,7 +29,7 @@ export class RokuDeploy {
     //store the import on the class to make testing easier
     public fsExtra = _fsExtra;
 
-    public screenshotDir = path.join(tempDir, '/roku-deploy/screenshots/');
+    public screenshotDir = path.join(util.tempDir, '/roku-deploy/screenshots/');
 
     /**
      * Copies all of the referenced files to the staging folder
@@ -1316,7 +1314,7 @@ export class RokuDeploy {
                 const result = {};
                 // sanitize/normalize values to their native formats, and also convert property names to camelCase
                 for (let key in deviceInfo) {
-                    result[lodash.camelCase(key)] = this.normalizeDeviceInfoFieldValue(deviceInfo[key]);
+                    result[util.camelCase(key)] = this.normalizeDeviceInfoFieldValue(deviceInfo[key]);
                 }
                 deviceInfo = result;
             }

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -3,6 +3,8 @@ import { expect } from 'chai';
 import * as fsExtra from 'fs-extra';
 import { tempDir } from './testUtils.spec';
 import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
 import * as dns from 'dns';
 import { createSandbox } from 'sinon';
 const sinon = createSandbox();
@@ -349,6 +351,76 @@ describe('util', () => {
             expect(
                 await util.dnsLookup('some-host', true)
             ).to.eql('some-host');
+        });
+    });
+
+    describe('tempDir', () => {
+        it('returns the realpath-resolved OS temp directory', () => {
+            expect(util.tempDir).to.equal(fs.realpathSync(os.tmpdir()));
+        });
+
+        it('caches the value after first access', () => {
+            const stub = sinon.stub(fs, 'realpathSync').returns('/fake/tmp' as any);
+            //force a fresh resolution
+            util['_tempDir'] = undefined;
+            expect(util.tempDir).to.equal('/fake/tmp');
+            //second access should be cached (realpathSync not called again)
+            expect(util.tempDir).to.equal('/fake/tmp');
+            expect(stub.callCount).to.equal(1);
+        });
+    });
+
+    describe('camelCase', () => {
+        it('defaults nullish input to empty string', () => {
+            expect(util.camelCase(undefined as any)).to.equal('');
+            expect(util.camelCase(null as any)).to.equal('');
+            expect(util.camelCase('')).to.equal('');
+        });
+
+        it('matches lodash across the full Roku device-info key set and edge cases', () => {
+            const cases: Array<[string, string]> = [
+                ['udn', 'udn'],
+                ['device-id', 'deviceId'],
+                ['serial-number', 'serialNumber'],
+                ['advertising-id', 'advertisingId'],
+                ['is-tv', 'isTv'],
+                ['mobile-has-live-tv', 'mobileHasLiveTv'],
+                ['ui-resolution', 'uiResolution'],
+                ['wifi-mac', 'wifiMac'],
+                ['has-wifi-extender', 'hasWifiExtender'],
+                ['has-wifi-5g-support', 'hasWifi5GSupport'],
+                ['ethernet-mac', 'ethernetMac'],
+                ['time-zone-offset', 'timeZoneOffset'],
+                ['supports-find-remote', 'supportsFindRemote'],
+                ['find-remote-is-possible', 'findRemoteIsPossible'],
+                ['supports-rva', 'supportsRva'],
+                ['keyed-developer-id', 'keyedDeveloperId'],
+                ['supports-ecs-textedit', 'supportsEcsTextedit'],
+                ['supports-wake-on-wlan', 'supportsWakeOnWlan'],
+                ['has-play-on-roku', 'hasPlayOnRoku'],
+                ['support-url', 'supportUrl'],
+                ['trc-version', 'trcVersion'],
+                ['av-sync-calibration-enabled', 'avSyncCalibrationEnabled'],
+                ['brightscript-debugger-version', 'brightscriptDebuggerVersion'],
+                //edge cases: word boundaries on case/digit transitions and separators
+                ['foo_bar', 'fooBar'],
+                ['FOO_BAR', 'fooBar'],
+                ['fooBar', 'fooBar'],
+                ['XMLHttpRequest', 'xmlHttpRequest'],
+                ['foo3bar', 'foo3Bar'],
+                ['3foo', '3Foo'],
+                ['foo--bar', 'fooBar'],
+                ['  leading-space', 'leadingSpace'],
+                ['a1b2c3', 'a1B2C3'],
+                ['IPAddress', 'ipAddress'],
+                ['parseHTML5Video', 'parseHtml5Video'],
+                ['wifi5g', 'wifi5G'],
+                ['AB1CD', 'ab1Cd'],
+                ['a', 'a']
+            ];
+            for (const [input, expected] of cases) {
+                expect(util.camelCase(input), input).to.equal(expected);
+            }
         });
     });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as dns from 'dns';
 import * as crypto from 'crypto';
 import * as micromatch from 'micromatch';
@@ -261,6 +262,43 @@ export class Util {
             return String.fromCharCode(num);
         });
     }
+
+    /**
+     * The OS temp directory, with symlinks resolved (e.g. on macOS `/var` -> `/private/var`).
+     * Replaces the `temp-dir` package. Cached on first access.
+     */
+    public get tempDir() {
+        if (this._tempDir === undefined) {
+            this._tempDir = fs.realpathSync(os.tmpdir());
+        }
+        return this._tempDir;
+    }
+
+    private _tempDir: string;
+
+    /**
+     * Convert a string to camelCase (e.g. `device-id` -> `deviceId`, `has-wifi-5g-support` -> `hasWifi5GSupport`).
+     * Replaces `lodash.camelCase`. Reproduces lodash's word-splitting (boundaries at non-alphanumeric
+     * runs, lower->UPPER transitions, acronym->Word transitions, and digit<->letter transitions),
+     * verified against lodash across the full Roku device-info key set.
+     */
+    public camelCase(value: string) {
+        let matches = String(value ?? '').matchAll(Util.wordSplitRegex);
+        let result = '';
+        let index = 0;
+        for (let match of matches) {
+            let word = match[0].toLowerCase();
+            if (index === 0) {
+                result += word;
+            } else {
+                result += word.charAt(0).toUpperCase() + word.slice(1);
+            }
+            index++;
+        }
+        return result;
+    }
+
+    private static wordSplitRegex = /[A-Z\xc0-\xd6\xd8-\xde]?[a-z\xdf-\xf6\xf8-\xff]+(?:['’](?:d|ll|m|re|s|t|ve))?(?=[A-Z\xc0-\xd6\xd8-\xde]|\b|_|\d)|[A-Z\xc0-\xd6\xd8-\xde]+(?:['’](?:D|LL|M|RE|S|T|VE))?(?=[A-Z\xc0-\xd6\xd8-\xde][a-z\xdf-\xf6\xf8-\xff]|\b|_|\d)|[A-Z\xc0-\xd6\xd8-\xde]?[a-z\xdf-\xf6\xf8-\xff]+|[A-Z\xc0-\xd6\xd8-\xde]+|\d+/g;
 
 }
 


### PR DESCRIPTION
## Inline `lodash.camelCase` and `temp-dir` into `util`

Second PR in the dependency-reduction stack (based on `chore/consolidate-date-libs` / #297). Removes two more single-use production deps by inlining faithful replacements onto the existing `util` singleton.

### What changed
| Removed dep | Old use | Replacement |
|---|---|---|
| `lodash` | one `lodash.camelCase(key)` on Roku device-info keys | `util.camelCase` |
| `temp-dir` | one `path.join(tempDir, …)` for the screenshot dir | `util.tempDir` (cached `fs.realpathSync(os.tmpdir())`) |

`util.camelCase` reproduces lodash's word-splitting — boundaries at non-alphanumeric runs, lower→UPPER transitions, acronym→Word transitions, and **digit↔letter transitions**. The last one matters: `has-wifi-5g-support` → `hasWifi5GSupport` (capital G), which a naive `replace(/-(.)/)` gets wrong. The implementation was diffed against `lodash.camelCase` across the **entire `getDeviceInfo` device-info key set** plus edge cases (`XMLHttpRequest`→`xmlHttpRequest`, `a1b2c3`→`a1B2C3`, `AB1CD`→`ab1Cd`, `wifi5g`→`wifi5G`) — 0 mismatches. Those cases are encoded in the new `util.camelCase` tests.

The `@types/lodash` devDependency is dropped as orphaned. New helpers live on the `util` singleton (already imported by `RokuDeploy`, so no new import cycles).

### Verification
- ✅ `npm run build` — clean (tsc, exit 0)
- ✅ `npm run lint` — clean
- ✅ `npm test` — 395 passing, 2 pending, **100% coverage** (statements / branches / functions / lines)

### Running total (across the dependency-reduction PR stack)

| Metric | Baseline (master) | PR #297 (date libs) | This PR |
|---|---|---|---|
| Direct prod deps | 17 | 13 | **11** |
| Total prod modules | 128 | 124 | **122** |

Both `lodash` and `temp-dir` left the installed production tree entirely (neither is retained transitively).

> Notes from this round's audit, for context: `is-glob` was **not** inlined — it stays in the tree transitively via `fast-glob` → `glob-parent`, so removing the direct dep would drop 0 modules. `chalk` was intentionally kept (its TTY/`NO_COLOR`/`FORCE_COLOR` color-support detection isn't worth reimplementing). `@types/request`/`request` are kept (needed for `postman-request` typings; a needle migration is planned separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
