### PR TITLE
Declare picomatch as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "jsonc-parser": "^2.3.0",
                 "jszip": "^3.6.0",
                 "micromatch": "^4.0.4",
+                "picomatch": "^2.3.2",
                 "postman-request": "^2.88.1-postman.48",
                 "semver": "^7.7.3",
                 "xml2js": "^0.5.0"
@@ -31,6 +32,7 @@
                 "@types/micromatch": "^4.0.2",
                 "@types/mocha": "^10.0.0",
                 "@types/node": "^18.19.0",
+                "@types/picomatch": "^2.3.4",
                 "@types/semver": "^7.7.1",
                 "@types/sinon": "^10.0.4",
                 "@types/xml2js": "^0.4.5",
@@ -788,6 +790,13 @@
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
+        },
+        "node_modules/@types/picomatch": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-2.3.4.tgz",
+            "integrity": "sha512-0so8lU8O5zatZS/2Fi4zrwks+vZv7e0dygrgEZXljODXBig97l4cPQD+9LabXfGJOWwoRkTVz6Q4edZvD12UOA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/request": {
             "version": "2.48.13",
@@ -4080,6 +4089,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -5923,6 +5933,12 @@
             "requires": {
                 "undici-types": "~5.26.4"
             }
+        },
+        "@types/picomatch": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-2.3.4.tgz",
+            "integrity": "sha512-0so8lU8O5zatZS/2Fi4zrwks+vZv7e0dygrgEZXljODXBig97l4cPQD+9LabXfGJOWwoRkTVz6Q4edZvD12UOA==",
+            "dev": true
         },
         "@types/request": {
             "version": "2.48.13",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "jsonc-parser": "^2.3.0",
         "jszip": "^3.6.0",
         "micromatch": "^4.0.4",
+        "picomatch": "^2.3.2",
         "postman-request": "^2.88.1-postman.48",
         "semver": "^7.7.3",
         "xml2js": "^0.5.0"
@@ -38,6 +39,7 @@
         "@types/micromatch": "^4.0.2",
         "@types/mocha": "^10.0.0",
         "@types/node": "^18.19.0",
+        "@types/picomatch": "^2.3.4",
         "@types/semver": "^7.7.1",
         "@types/sinon": "^10.0.4",
         "@types/xml2js": "^0.4.5",


### PR DESCRIPTION
## Declare `picomatch` as a direct dependency (fix phantom dependency)

Third PR in the dependency-reduction stack (based on #298). This one is a **correctness fix**, not a reduction: it ensures every package we `require()`/`import` in non-test source is one of our **own** declared production dependencies, rather than something we rely on resolving transitively.

### The problem
[RokuDeploy.ts:9](src/RokuDeploy.ts#L9) imports `picomatch` and calls it as a runtime value ([RokuDeploy.ts:305,310](src/RokuDeploy.ts#L305)), but `picomatch` was **never declared** in `package.json`. It only resolved because `micromatch` happens to pull in `picomatch@2.3.2` transitively. That's a phantom dependency — a future dependency-tree change (e.g. micromatch swapping its matcher engine) could remove it and break `require('picomatch')` at runtime, with nothing in our manifest catching it.

### Audit
I extracted **every** external `import`/`require` across non-test source and cross-checked each against `package.json`:

| Package | Declared? |
|---|---|
| `fs-extra`, `micromatch`, `fast-glob`, `chalk`, `postman-request`, `jszip`, `is-glob`, `xml2js`, `jsonc-parser`, `semver` | ✅ in `dependencies` |
| `request` (type-only) | ✅ via `@types/request` |
| Node built-ins (`path`, `fs`, `os`, `dns`, `crypto`, `perf_hooks`) | ✅ N/A |
| **`picomatch`** | ❌ **undeclared** — fixed here |

`picomatch` was the only undeclared external package.

### The fix
- Add `picomatch` (`^2.3.2`) to `dependencies` — pinned to dedupe with micromatch's `^2.3.1`, so **0 modules added** to the tree.
- Add `@types/picomatch` to `devDependencies`.

### Verification
- ✅ `npm run build` — clean (tsc, exit 0)
- ✅ `npm run lint` — clean
- ✅ `npm test` — 395 passing, 100% coverage
- ✅ `picomatch@2.3.2` resolves to a single deduped copy (`npm ls picomatch`)

### Running total (across the dependency-reduction PR stack)

| Metric | Baseline (master) | #297 (date libs) | #298 (lodash/temp-dir) | This PR |
|---|---|---|---|---|
| Direct prod deps | 17 | 13 | 11 | **12** |
| Total prod modules | 128 | 124 | 122 | **122** |

Direct prod deps tick **up** by one here (declaring a real, previously-hidden dependency), while total prod modules stay flat at **122** — picomatch was already installed transitively; this just makes the existing runtime usage honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
