### PR TITLE
Extract normalizeDeviceInfo helper from getDeviceInfo

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -691,9 +691,9 @@ describe('RokuDeploy', () => {
         });
     });
 
-    describe('normalizeDeviceInfo', () => {
+    describe('enhanceDeviceInfo', () => {
         it('camel-cases keys and normalizes values', () => {
-            const result = rokuDeploy.normalizeDeviceInfo({
+            const result = rokuDeploy.enhanceDeviceInfo({
                 'serial-number': 'abc123',
                 'software-build': '4170',
                 'uptime': '19799',
@@ -724,11 +724,11 @@ describe('RokuDeploy', () => {
             const enhanced = await rokuDeploy.getDeviceInfo({ host: '192.168.1.10', remotePort: 8060, enhance: true });
             const raw = await rokuDeploy.getDeviceInfo({ host: '192.168.1.10', remotePort: 8060 });
 
-            expect(rokuDeploy.normalizeDeviceInfo(raw)).to.eql(enhanced);
+            expect(rokuDeploy.enhanceDeviceInfo(raw)).to.eql(enhanced);
         });
 
         it('returns an empty object for an empty input', () => {
-            expect(rokuDeploy.normalizeDeviceInfo({})).to.eql({});
+            expect(rokuDeploy.enhanceDeviceInfo({})).to.eql({});
         });
     });
 

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -691,6 +691,47 @@ describe('RokuDeploy', () => {
         });
     });
 
+    describe('normalizeDeviceInfo', () => {
+        it('camel-cases keys and normalizes values', () => {
+            const result = rokuDeploy.normalizeDeviceInfo({
+                'serial-number': 'abc123',
+                'software-build': '4170',
+                'uptime': '19799',
+                'is-tv': 'false',
+                'supports-ethernet': 'true',
+                'support-url': '3&amp;4'
+            });
+            expect(result).to.eql({
+                serialNumber: 'abc123',
+                softwareBuild: 4170,
+                uptime: 19799,
+                isTv: false,
+                supportsEthernet: true,
+                supportUrl: '3&4'
+            });
+        });
+
+        it('produces the same result as getDeviceInfo with enhance enabled', async () => {
+            const deviceInfoBody = `<device-info>
+                <serial-number>abc123</serial-number>
+                <software-build>4170</software-build>
+                <is-tv>false</is-tv>
+                <developer-enabled>true</developer-enabled>
+                <support-url>3&amp;4</support-url>
+            </device-info>`;
+
+            mockDoGetRequest(deviceInfoBody);
+            const enhanced = await rokuDeploy.getDeviceInfo({ host: '192.168.1.10', remotePort: 8060, enhance: true });
+            const raw = await rokuDeploy.getDeviceInfo({ host: '192.168.1.10', remotePort: 8060 });
+
+            expect(rokuDeploy.normalizeDeviceInfo(raw)).to.eql(enhanced);
+        });
+
+        it('returns an empty object for an empty input', () => {
+            expect(rokuDeploy.normalizeDeviceInfo({})).to.eql({});
+        });
+    });
+
     describe('normalizeDeviceInfoFieldValue', () => {
         it('converts normal values', () => {
             expect(rokuDeploy.normalizeDeviceInfoFieldValue('true')).to.eql(true);

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -1311,12 +1311,7 @@ export class RokuDeploy {
             } as Record<string, any>;
 
             if (options.enhance) {
-                const result = {};
-                // sanitize/normalize values to their native formats, and also convert property names to camelCase
-                for (let key in deviceInfo) {
-                    result[util.camelCase(key)] = this.normalizeDeviceInfoFieldValue(deviceInfo[key]);
-                }
-                deviceInfo = result;
+                return this.normalizeDeviceInfo(deviceInfo);
             }
             return deviceInfo;
         } catch (e) {
@@ -1346,6 +1341,23 @@ export class RokuDeploy {
             throw new errors.UnknownDeviceResponseError('Could not retrieve device ECP setting');
         }
 
+    }
+
+    /**
+     * Enhance a raw device-info object into its normalized form. This camel-cases the property names and
+     * normalizes each value to its native format (boolean strings to booleans, number strings to numbers,
+     * decoding HtmlEntities, etc.). This is the same enhancement `getDeviceInfo` applies when called with
+     * `{ enhance: true }`, exposed separately so callers that already have a raw device-info object can
+     * enhance it without making another request to the device.
+     * @param deviceInfo the raw device-info object to enhance
+     */
+    public normalizeDeviceInfo(deviceInfo: DeviceInfoRaw): DeviceInfo {
+        const result = {} as DeviceInfo;
+        // sanitize/normalize values to their native formats, and also convert property names to camelCase
+        for (let key in deviceInfo) {
+            result[util.camelCase(key)] = this.normalizeDeviceInfoFieldValue(deviceInfo[key]);
+        }
+        return result;
     }
 
     /**

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -1311,7 +1311,7 @@ export class RokuDeploy {
             } as Record<string, any>;
 
             if (options.enhance) {
-                return this.normalizeDeviceInfo(deviceInfo);
+                return this.enhanceDeviceInfo(deviceInfo);
             }
             return deviceInfo;
         } catch (e) {
@@ -1351,7 +1351,7 @@ export class RokuDeploy {
      * enhance it without making another request to the device.
      * @param deviceInfo the raw device-info object to enhance
      */
-    public normalizeDeviceInfo(deviceInfo: DeviceInfoRaw): DeviceInfo {
+    public enhanceDeviceInfo(deviceInfo: DeviceInfoRaw): DeviceInfo {
         const result = {} as DeviceInfo;
         // sanitize/normalize values to their native formats, and also convert property names to camelCase
         for (let key in deviceInfo) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,13 +14,13 @@ let createPackage = RokuDeploy.prototype.createPackage.bind(rokuDeploy);
 let deleteInstalledChannel = RokuDeploy.prototype.deleteInstalledChannel.bind(rokuDeploy);
 let deploy = RokuDeploy.prototype.deploy.bind(rokuDeploy);
 let deployAndSignPackage = RokuDeploy.prototype.deployAndSignPackage.bind(rokuDeploy);
+let enhanceDeviceInfo = RokuDeploy.prototype.enhanceDeviceInfo.bind(rokuDeploy);
 let getDestPath = RokuDeploy.prototype.getDestPath.bind(rokuDeploy);
 let getDeviceInfo = RokuDeploy.prototype.getDeviceInfo.bind(rokuDeploy);
 let getFilePaths = RokuDeploy.prototype.getFilePaths.bind(rokuDeploy);
 let getOptions = RokuDeploy.prototype.getOptions.bind(rokuDeploy);
 let getOutputPkgFilePath = RokuDeploy.prototype.getOutputPkgFilePath.bind(rokuDeploy);
 let getOutputZipFilePath = RokuDeploy.prototype.getOutputZipFilePath.bind(rokuDeploy);
-let normalizeDeviceInfo = RokuDeploy.prototype.normalizeDeviceInfo.bind(rokuDeploy);
 let normalizeFilesArray = RokuDeploy.prototype.normalizeFilesArray.bind(rokuDeploy);
 let normalizeRootDir = RokuDeploy.prototype.normalizeRootDir.bind(rokuDeploy);
 let parseManifest = RokuDeploy.prototype.parseManifest.bind(rokuDeploy);
@@ -40,13 +40,13 @@ export {
     deleteInstalledChannel,
     deploy,
     deployAndSignPackage,
+    enhanceDeviceInfo,
     getDestPath,
     getDeviceInfo,
     getFilePaths,
     getOptions,
     getOutputPkgFilePath,
     getOutputZipFilePath,
-    normalizeDeviceInfo,
     normalizeFilesArray,
     normalizeRootDir,
     parseManifest,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ let getFilePaths = RokuDeploy.prototype.getFilePaths.bind(rokuDeploy);
 let getOptions = RokuDeploy.prototype.getOptions.bind(rokuDeploy);
 let getOutputPkgFilePath = RokuDeploy.prototype.getOutputPkgFilePath.bind(rokuDeploy);
 let getOutputZipFilePath = RokuDeploy.prototype.getOutputZipFilePath.bind(rokuDeploy);
+let normalizeDeviceInfo = RokuDeploy.prototype.normalizeDeviceInfo.bind(rokuDeploy);
 let normalizeFilesArray = RokuDeploy.prototype.normalizeFilesArray.bind(rokuDeploy);
 let normalizeRootDir = RokuDeploy.prototype.normalizeRootDir.bind(rokuDeploy);
 let parseManifest = RokuDeploy.prototype.parseManifest.bind(rokuDeploy);
@@ -45,6 +46,7 @@ export {
     getOptions,
     getOutputPkgFilePath,
     getOutputZipFilePath,
+    normalizeDeviceInfo,
     normalizeFilesArray,
     normalizeRootDir,
     parseManifest,


### PR DESCRIPTION
Exposes the device-info enhancement (camel-case keys plus value normalization) as a public `enhanceDeviceInfo(DeviceInfoRaw): DeviceInfo` method, so callers that already have a raw device-info object can enhance it without making another request to the device. `getDeviceInfo({ enhance: true })` now delegates to it.

Used by roku-debug and the vscode extension to reuse already-gathered device-info during debug launch instead of issuing a redundant request.