### PR TITLE
Fix: potential crash in normalizeDeviceInfoFieldValue when supplied non-string values

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -712,6 +712,19 @@ describe('RokuDeploy', () => {
             expect(rokuDeploy.normalizeDeviceInfoFieldValue('3&4')).to.eql('3&4');
             expect(rokuDeploy.normalizeDeviceInfoFieldValue('3&amp;4')).to.eql('3&4');
         });
+
+        it('returns non-string values unchanged', () => {
+            expect(rokuDeploy.normalizeDeviceInfoFieldValue(42)).to.eql(42);
+            expect(rokuDeploy.normalizeDeviceInfoFieldValue(0)).to.eql(0);
+            expect(rokuDeploy.normalizeDeviceInfoFieldValue(true)).to.eql(true);
+            expect(rokuDeploy.normalizeDeviceInfoFieldValue(false)).to.eql(false);
+            expect(rokuDeploy.normalizeDeviceInfoFieldValue(null)).to.be.null;
+            expect(rokuDeploy.normalizeDeviceInfoFieldValue(undefined)).to.be.undefined;
+            const obj = { name: 'roku' };
+            expect(rokuDeploy.normalizeDeviceInfoFieldValue(obj)).to.equal(obj);
+            const arr = [1, 2, 3];
+            expect(rokuDeploy.normalizeDeviceInfoFieldValue(arr)).to.equal(arr);
+        });
     });
 
 

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -1354,6 +1354,10 @@ export class RokuDeploy {
      * @param deviceInfo
      */
     public normalizeDeviceInfoFieldValue(value: any) {
+        // non-string values have nothing to normalize; return them unchanged
+        if (typeof value !== 'string') {
+            return value;
+        }
         let num: number;
         // convert 'true' and 'false' string values to boolean
         if (value === 'true') {


### PR DESCRIPTION
`normalizeDeviceInfoFieldValue` called `value.trim()` unconditionally, which threw a `TypeError` for any non-string input (number, boolean, null, undefined, object). This adds a guard that returns non-string values unchanged. String handling is unchanged.