### PR TITLE
chore: Add device tests to CI (self-hosted)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to `.env` and fill in the connection info for a real Roku device.
+# The device test suite (`npm run test:device`) reads these to know which device to target.
+# `.env` is gitignored so your device credentials never get committed.
+
+# IP address or hostname of the Roku device to run the device tests against
+ROKU_HOST=192.168.1.31
+
+# Developer password for that device (set when you enabled developer mode)
+ROKU_PASSWORD=aaaa

--- a/.github/workflows/on-device-tests.yml
+++ b/.github/workflows/on-device-tests.yml
@@ -1,0 +1,22 @@
+name: on-device-tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  on-device-tests:
+    runs-on: [self-hosted, roku-latest, enabled]
+    env:
+      #the self-hosted runner points these at its attached Roku device. Configure them as repo/org
+      #secrets (or on the runner itself). Locally, developers use a .env file instead (see .env.example).
+      ROKU_HOST: ${{ secrets.ROKU_HOST }}
+      ROKU_PASSWORD: ${{ secrets.ROKU_PASSWORD }}
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: "18.20.4"
+      - run: npm ci
+      - run: npm run test:device

--- a/.github/workflows/on-device-tests.yml
+++ b/.github/workflows/on-device-tests.yml
@@ -8,11 +8,6 @@ on:
 jobs:
   on-device-tests:
     runs-on: [self-hosted, roku-latest, enabled]
-    env:
-      #the self-hosted runner points these at its attached Roku device. Configure them as repo/org
-      #secrets (or on the runner itself). Locally, developers use a .env file instead (see .env.example).
-      ROKU_HOST: ${{ secrets.ROKU_HOST }}
-      ROKU_PASSWORD: ${{ secrets.ROKU_PASSWORD }}
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ out
 coverage
 .nyc_output
 *.zip
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
                 "@typescript-eslint/parser": "5.1.0",
                 "audit-ci": "^7.1.0",
                 "chai": "^4.3.4",
+                "dotenv": "^17.4.2",
                 "eslint": "8.0.1",
                 "mocha": "^10.8.2",
                 "nyc": "^15.1.0",
@@ -1551,6 +1552,19 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
             }
         },
         "node_modules/duplexer": {
@@ -5733,6 +5747,12 @@
             "requires": {
                 "esutils": "^2.0.2"
             }
+        },
+        "dotenv": {
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+            "dev": true
         },
         "duplexer": {
             "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "audit": "npm audit || audit-ci --config ./audit-ci.jsonc",
         "test": "nyc mocha \"src/**/*.spec.ts\" --exclude \"src/device.spec.ts\"",
         "test:nocover": "mocha \"src/**/*.spec.ts\" --exclude \"src/device.spec.ts\"",
-        "test:device": "nyc mocha src/device.spec.ts",
+        "test:device": "mocha src/device.spec.ts",
         "test:all": "nyc mocha \"src/**/*.spec.ts\"",
         "test-without-sourcemaps": "npm run build && nyc mocha dist/**/*.spec.js",
         "package": "npm run build && npm pack"
@@ -47,6 +47,7 @@
         "@typescript-eslint/parser": "5.1.0",
         "audit-ci": "^7.1.0",
         "chai": "^4.3.4",
+        "dotenv": "^17.4.2",
         "eslint": "8.0.1",
         "mocha": "^10.8.2",
         "nyc": "^15.1.0",

--- a/src/device.spec.ts
+++ b/src/device.spec.ts
@@ -2,11 +2,25 @@ import * as assert from 'assert';
 import * as fsExtra from 'fs-extra';
 import * as net from 'net';
 import * as http from 'http';
+import * as path from 'path';
 import * as semver from 'semver';
+import * as dotenv from 'dotenv';
 import * as rokuDeploy from './index';
 import * as errors from './Errors';
 import { cwd, expectPathExists, expectThrowsAsync, outDir, rootDir, tempDir, writeFiles } from './testUtils.spec';
 import undent from 'undent';
+
+//load device connection info from a .env file at the repo root (if present), then fall back to any
+//pre-existing environment variables. This is how CI/CD (and local dev) point the device suite at a
+//real Roku without hardcoding host/password into the repo. See .env.example.
+dotenv.config({
+    path: path.resolve(__dirname, '../.env'),
+    override: true,
+    quiet: true
+});
+
+const HOST = process.env.ROKU_HOST;
+const PASSWORD = process.env.ROKU_PASSWORD;
 
 //socket teardown callbacks, drained in afterEach so the suite doesn't hang open
 const cleanups: Array<() => void> = [];
@@ -20,15 +34,25 @@ const REQUEST_TIMEOUT = 15_000;
 describe('device', function device() {
     let options: rokuDeploy.RokuDeployOptions;
 
+    before(() => {
+        //fail fast with a clear message rather than letting every test time out against an empty host
+        if (!HOST || !PASSWORD) {
+            throw new Error(
+                `Missing Roku device connection info. Set ROKU_HOST and ROKU_PASSWORD in "${path.resolve(__dirname, '../.env')}" ` +
+                `(see .env.example) or as environment variables before running "npm run test:device".`
+            );
+        }
+    });
+
     beforeEach(() => {
         fsExtra.emptyDirSync(tempDir);
         fsExtra.ensureDirSync(rootDir);
         process.chdir(rootDir);
         options = rokuDeploy.getOptions({
             outDir: outDir,
-            host: '192.168.1.31',
+            host: HOST,
             retainDeploymentArchive: true,
-            password: 'aaaa',
+            password: PASSWORD,
             devId: 'c6fdc2019903ac3332f624b0b2c2fe2c733c3e74',
             rekeySignedPackage: `${cwd}/testSignedPackage.pkg`,
             signingPassword: 'drRCEVWP/++K5TYnTtuAfQ=='


### PR DESCRIPTION
Adds the device test suite to CI/CD as a dedicated **self-hosted** job, following the same pattern as `roku-test-automation`.

Stacked on top of `migrate-postman-request-to-needle` (base branch is that PR, not master).

## What's included

- **`.github/workflows/on-device-tests.yml`** — new workflow that runs on the self-hosted runner (`[self-hosted, roku-latest, enabled]`) and invokes `npm run test:device`. Identical to roku-test-automation's `on-device-tests.yml`.
- **`.env` loading** — `src/device.spec.ts` now loads device connection info from a repo-root `.env` (via `dotenv`), falling back to pre-existing environment variables (the self-hosted runner already provides `ROKU_HOST` / `ROKU_PASSWORD` in its environment). Fails fast with a clear message when they're missing, instead of every test timing out against an empty host.
- **`.env.example`** — documents the variables for local dev. `.env` itself is gitignored so device credentials are never committed.
- **`test:device`** now runs plain `mocha` (dropped `nyc`) — device tests exercise real-device behavior, not code coverage, so the 100% coverage gate no longer (incorrectly) applies to them.

## Notes

- The self-hosted runner labels and Node version mirror roku-test-automation's `on-device-tests.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
