### PR TITLE
Add option to get screenshot as a buffer

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -3206,7 +3206,7 @@ describe('RokuDeploy', () => {
             let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/screenshot.png` });
             expect(result.buffer).to.be.instanceOf(Buffer);
             expect(result.buffer.toString()).to.equal('fake-image-data');
-            expect(result.filePath).to.equal(`${tempDir}/screenshot.png`);
+            expect(result.filePath).to.equal(path.join(tempDir, 'screenshot.png'));
             expect(fsExtra.existsSync(result.filePath)).to.be.true;
         });
 

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -3097,6 +3097,85 @@ describe('RokuDeploy', () => {
             expect(path.basename(result)).to.equal('myFile.jpg');
             expect(fsExtra.existsSync(result));
         });
+
+        it('returns Buffer when returnBuffer is true', async () => {
+            let body = getFakeResponseBody(`
+                Shell.create('Roku.Message').trigger('Set message type', 'success').trigger('Set message content', 'Screenshot ok').trigger('Render', node);
+
+                var screenshoot = document.createElement('div');
+                screenshoot.innerHTML = '<hr /><img src="pkgs/dev.png?time=1649939615">';
+                node.appendChild(screenshoot);
+            `);
+
+            const testImageData = Buffer.from('fake-image-data');
+            onHandler = (event, callback) => {
+                if (event === 'response') {
+                    callback({
+                        statusCode: 200
+                    });
+                } else if (event === 'data') {
+                    callback(testImageData);
+                } else if (event === 'end') {
+                    callback();
+                }
+            };
+
+            mockDoPostRequest(body);
+            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', returnBuffer: true });
+            expect(result).to.be.instanceOf(Buffer);
+            expect(result.toString()).to.equal('fake-image-data');
+        });
+
+        it('ignores out option when returnBuffer is true', async () => {
+            let body = getFakeResponseBody(`
+                Shell.create('Roku.Message').trigger('Set message type', 'success').trigger('Set message content', 'Screenshot ok').trigger('Render', node);
+
+                var screenshoot = document.createElement('div');
+                screenshoot.innerHTML = '<hr /><img src="pkgs/dev.png?time=1649939615">';
+                node.appendChild(screenshoot);
+            `);
+
+            const testImageData = Buffer.from('fake-image-data');
+            onHandler = (event, callback) => {
+                if (event === 'response') {
+                    callback({
+                        statusCode: 200
+                    });
+                } else if (event === 'data') {
+                    callback(testImageData);
+                } else if (event === 'end') {
+                    callback();
+                }
+            };
+
+            mockDoPostRequest(body);
+            // Pass out option, but it should be ignored when returnBuffer is true
+            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/should-not-exist.png`, returnBuffer: true });
+            expect(result).to.be.instanceOf(Buffer);
+            // Verify file was NOT created
+            expect(fsExtra.existsSync(`${tempDir}/should-not-exist.png`)).to.be.false;
+        });
+
+        it('throws error when returnBuffer request fails', async () => {
+            let body = getFakeResponseBody(`
+                Shell.create('Roku.Message').trigger('Set message type', 'success').trigger('Set message content', 'Screenshot ok').trigger('Render', node);
+
+                var screenshoot = document.createElement('div');
+                screenshoot.innerHTML = '<hr /><img src="pkgs/dev.png?time=1649939615">';
+                node.appendChild(screenshoot);
+            `);
+
+            onHandler = (event, callback) => {
+                if (event === 'response') {
+                    callback({
+                        statusCode: 500
+                    });
+                }
+            };
+
+            mockDoPostRequest(body);
+            await expectThrowsAsync(rokuDeploy.captureScreenshot({ host: options.host, password: 'password', returnBuffer: true }));
+        });
     });
 
     describe('makeZip', () => {

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -2866,19 +2866,23 @@ describe('RokuDeploy', () => {
                 node.appendChild(screenshoot);
             `);
 
+            const testImageData = Buffer.from('fake-png-data');
             onHandler = (event, callback) => {
                 if (event === 'response') {
-                    callback({
-                        statusCode: 200
-                    });
+                    callback({ statusCode: 200 });
+                } else if (event === 'data') {
+                    callback(testImageData);
+                } else if (event === 'end') {
+                    callback();
                 }
             };
 
             mockDoPostRequest(body);
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password' });
-            expect(result).not.to.be.undefined;
-            expect(path.extname(result)).to.equal('.png');
-            expect(fsExtra.existsSync(result));
+            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: true });
+            expect(result.buffer).to.be.instanceOf(Buffer);
+            expect(result.filePath).not.to.be.undefined;
+            expect(path.extname(result.filePath)).to.equal('.png');
+            expect(fsExtra.existsSync(result.filePath));
         });
 
         it('handles the device returning a jpg', async () => {
@@ -2890,19 +2894,23 @@ describe('RokuDeploy', () => {
                 node.appendChild(screenshoot);
             `);
 
+            const testImageData = Buffer.from('fake-jpg-data');
             onHandler = (event, callback) => {
                 if (event === 'response') {
-                    callback({
-                        statusCode: 200
-                    });
+                    callback({ statusCode: 200 });
+                } else if (event === 'data') {
+                    callback(testImageData);
+                } else if (event === 'end') {
+                    callback();
                 }
             };
 
             mockDoPostRequest(body);
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password' });
-            expect(result).not.to.be.undefined;
-            expect(path.extname(result)).to.equal('.jpg');
-            expect(fsExtra.existsSync(result));
+            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: true });
+            expect(result.buffer).to.be.instanceOf(Buffer);
+            expect(result.filePath).not.to.be.undefined;
+            expect(path.extname(result.filePath)).to.equal('.jpg');
+            expect(fsExtra.existsSync(result.filePath));
         });
 
         it('take a screenshot from the device and saves to supplied dir', async () => {
@@ -2914,19 +2922,22 @@ describe('RokuDeploy', () => {
                 node.appendChild(screenshoot);
             `);
 
+            const testImageData = Buffer.from('fake-image-data');
             onHandler = (event, callback) => {
                 if (event === 'response') {
-                    callback({
-                        statusCode: 200
-                    });
+                    callback({ statusCode: 200 });
+                } else if (event === 'data') {
+                    callback(testImageData);
+                } else if (event === 'end') {
+                    callback();
                 }
             };
 
             mockDoPostRequest(body);
             let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/myScreenShots/screenshot` });
-            expect(result).not.to.be.undefined;
-            expect(util.standardizePath(`${tempDir}/myScreenShots`)).to.equal(path.dirname(result));
-            expect(fsExtra.existsSync(result));
+            expect(result.filePath).not.to.be.undefined;
+            expect(util.standardizePath(`${tempDir}/myScreenShots`)).to.equal(path.dirname(result.filePath));
+            expect(fsExtra.existsSync(result.filePath));
         });
 
         it('saves to specified file', async () => {
@@ -2938,19 +2949,22 @@ describe('RokuDeploy', () => {
                 node.appendChild(screenshoot);
             `);
 
+            const testImageData = Buffer.from('fake-image-data');
             onHandler = (event, callback) => {
                 if (event === 'response') {
-                    callback({
-                        statusCode: 200
-                    });
+                    callback({ statusCode: 200 });
+                } else if (event === 'data') {
+                    callback(testImageData);
+                } else if (event === 'end') {
+                    callback();
                 }
             };
 
             mockDoPostRequest(body);
             let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/my` });
-            expect(result).not.to.be.undefined;
-            expect(util.standardizePath(tempDir)).to.equal(path.dirname(result));
-            expect(fsExtra.existsSync(path.join(tempDir, 'my.png')));
+            expect(result.filePath).not.to.be.undefined;
+            expect(util.standardizePath(tempDir)).to.equal(path.dirname(result.filePath));
+            expect(fsExtra.existsSync(path.join(tempDir, 'my')));
         });
 
         it('saves to specified file ignoring supplied file extension', async () => {
@@ -2962,22 +2976,26 @@ describe('RokuDeploy', () => {
                 node.appendChild(screenshoot);
             `);
 
+            const testImageData = Buffer.from('fake-image-data');
             onHandler = (event, callback) => {
                 if (event === 'response') {
-                    callback({
-                        statusCode: 200
-                    });
+                    callback({ statusCode: 200 });
+                } else if (event === 'data') {
+                    callback(testImageData);
+                } else if (event === 'end') {
+                    callback();
                 }
             };
 
             mockDoPostRequest(body);
             let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/my.jpg` });
-            expect(result).not.to.be.undefined;
-            expect(util.standardizePath(tempDir)).to.equal(path.dirname(result));
-            expect(fsExtra.existsSync(path.join(tempDir, 'my.jpg.png')));
+            expect(result.filePath).not.to.be.undefined;
+            expect(util.standardizePath(tempDir)).to.equal(path.dirname(result.filePath));
+            // Without autoExtension, file is saved exactly as specified
+            expect(fsExtra.existsSync(path.join(tempDir, 'my.jpg')));
         });
 
-        it('take a screenshot from the device and saves to temp', async () => {
+        it('returns buffer without saving to disk when out is not provided', async () => {
             let body = getFakeResponseBody(`
                 Shell.create('Roku.Message').trigger('Set message type', 'success').trigger('Set message content', 'Screenshot ok').trigger('Render', node);
 
@@ -2986,21 +3004,25 @@ describe('RokuDeploy', () => {
                 node.appendChild(screenshoot);
             `);
 
+            const testImageData = Buffer.from('fake-image-data');
             onHandler = (event, callback) => {
                 if (event === 'response') {
-                    callback({
-                        statusCode: 200
-                    });
+                    callback({ statusCode: 200 });
+                } else if (event === 'data') {
+                    callback(testImageData);
+                } else if (event === 'end') {
+                    callback();
                 }
             };
 
             mockDoPostRequest(body);
             let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password' });
-            expect(result).not.to.be.undefined;
-            expect(fsExtra.existsSync(result));
+            expect(result.buffer).to.be.instanceOf(Buffer);
+            expect(result.buffer.toString()).to.equal('fake-image-data');
+            expect(result.filePath).to.be.undefined;
         });
 
-        it('take a screenshot from the device and saves to temp but with the supplied file name (no extension added by default)', async () => {
+        it('saves with user-provided filename exactly when autoExtension is false', async () => {
             let body = getFakeResponseBody(`
                 Shell.create('Roku.Message').trigger('Set message type', 'success').trigger('Set message content', 'Screenshot ok').trigger('Render', node);
 
@@ -3009,20 +3031,23 @@ describe('RokuDeploy', () => {
                 node.appendChild(screenshoot);
             `);
 
+            const testImageData = Buffer.from('fake-image-data');
             onHandler = (event, callback) => {
                 if (event === 'response') {
-                    callback({
-                        statusCode: 200
-                    });
+                    callback({ statusCode: 200 });
+                } else if (event === 'data') {
+                    callback(testImageData);
+                } else if (event === 'end') {
+                    callback();
                 }
             };
 
             mockDoPostRequest(body);
             // With autoExtension: false (default), user-provided filename is used exactly
             let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/myFile` });
-            expect(result).not.to.be.undefined;
-            expect(path.basename(result)).to.equal('myFile');
-            expect(fsExtra.existsSync(result));
+            expect(result.filePath).not.to.be.undefined;
+            expect(path.basename(result.filePath)).to.equal('myFile');
+            expect(fsExtra.existsSync(result.filePath));
         });
 
         it('autoExtension: true appends device extension when user filename has no extension', async () => {
@@ -3034,19 +3059,22 @@ describe('RokuDeploy', () => {
                 node.appendChild(screenshoot);
             `);
 
+            const testImageData = Buffer.from('fake-image-data');
             onHandler = (event, callback) => {
                 if (event === 'response') {
-                    callback({
-                        statusCode: 200
-                    });
+                    callback({ statusCode: 200 });
+                } else if (event === 'data') {
+                    callback(testImageData);
+                } else if (event === 'end') {
+                    callback();
                 }
             };
 
             mockDoPostRequest(body);
             let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/myFile`, autoExtension: true });
-            expect(result).not.to.be.undefined;
-            expect(path.basename(result)).to.equal('myFile.jpg');
-            expect(fsExtra.existsSync(result));
+            expect(result.filePath).not.to.be.undefined;
+            expect(path.basename(result.filePath)).to.equal('myFile.jpg');
+            expect(fsExtra.existsSync(result.filePath));
         });
 
         it('autoExtension: true swaps extension when user extension does not match device', async () => {
@@ -3058,20 +3086,23 @@ describe('RokuDeploy', () => {
                 node.appendChild(screenshoot);
             `);
 
+            const testImageData = Buffer.from('fake-image-data');
             onHandler = (event, callback) => {
                 if (event === 'response') {
-                    callback({
-                        statusCode: 200
-                    });
+                    callback({ statusCode: 200 });
+                } else if (event === 'data') {
+                    callback(testImageData);
+                } else if (event === 'end') {
+                    callback();
                 }
             };
 
             mockDoPostRequest(body);
             // User provides .png but device returns .jpg - should swap to .jpg
             let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/myFile.png`, autoExtension: true });
-            expect(result).not.to.be.undefined;
-            expect(path.basename(result)).to.equal('myFile.jpg');
-            expect(fsExtra.existsSync(result));
+            expect(result.filePath).not.to.be.undefined;
+            expect(path.basename(result.filePath)).to.equal('myFile.jpg');
+            expect(fsExtra.existsSync(result.filePath));
         });
 
         it('autoExtension: true keeps extension when user extension matches device', async () => {
@@ -3083,22 +3114,25 @@ describe('RokuDeploy', () => {
                 node.appendChild(screenshoot);
             `);
 
+            const testImageData = Buffer.from('fake-image-data');
             onHandler = (event, callback) => {
                 if (event === 'response') {
-                    callback({
-                        statusCode: 200
-                    });
+                    callback({ statusCode: 200 });
+                } else if (event === 'data') {
+                    callback(testImageData);
+                } else if (event === 'end') {
+                    callback();
                 }
             };
 
             mockDoPostRequest(body);
             let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/myFile.jpg`, autoExtension: true });
-            expect(result).not.to.be.undefined;
-            expect(path.basename(result)).to.equal('myFile.jpg');
-            expect(fsExtra.existsSync(result));
+            expect(result.filePath).not.to.be.undefined;
+            expect(path.basename(result.filePath)).to.equal('myFile.jpg');
+            expect(fsExtra.existsSync(result.filePath));
         });
 
-        it('returns Buffer when returnBuffer is true', async () => {
+        it('saves to default temp location when out is true', async () => {
             let body = getFakeResponseBody(`
                 Shell.create('Roku.Message').trigger('Set message type', 'success').trigger('Set message content', 'Screenshot ok').trigger('Render', node);
 
@@ -3110,9 +3144,7 @@ describe('RokuDeploy', () => {
             const testImageData = Buffer.from('fake-image-data');
             onHandler = (event, callback) => {
                 if (event === 'response') {
-                    callback({
-                        statusCode: 200
-                    });
+                    callback({ statusCode: 200 });
                 } else if (event === 'data') {
                     callback(testImageData);
                 } else if (event === 'end') {
@@ -3121,12 +3153,13 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', returnBuffer: true });
-            expect(result).to.be.instanceOf(Buffer);
-            expect(result.toString()).to.equal('fake-image-data');
+            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: true });
+            expect(result.buffer).to.be.instanceOf(Buffer);
+            expect(result.filePath).not.to.be.undefined;
+            expect(fsExtra.existsSync(result.filePath)).to.be.true;
         });
 
-        it('ignores out option when returnBuffer is true', async () => {
+        it('returns buffer and filePath when out is provided', async () => {
             let body = getFakeResponseBody(`
                 Shell.create('Roku.Message').trigger('Set message type', 'success').trigger('Set message content', 'Screenshot ok').trigger('Render', node);
 
@@ -3138,9 +3171,7 @@ describe('RokuDeploy', () => {
             const testImageData = Buffer.from('fake-image-data');
             onHandler = (event, callback) => {
                 if (event === 'response') {
-                    callback({
-                        statusCode: 200
-                    });
+                    callback({ statusCode: 200 });
                 } else if (event === 'data') {
                     callback(testImageData);
                 } else if (event === 'end') {
@@ -3149,14 +3180,14 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            // Pass out option, but it should be ignored when returnBuffer is true
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/should-not-exist.png`, returnBuffer: true });
-            expect(result).to.be.instanceOf(Buffer);
-            // Verify file was NOT created
-            expect(fsExtra.existsSync(`${tempDir}/should-not-exist.png`)).to.be.false;
+            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/screenshot.png` });
+            expect(result.buffer).to.be.instanceOf(Buffer);
+            expect(result.buffer.toString()).to.equal('fake-image-data');
+            expect(result.filePath).to.equal(`${tempDir}/screenshot.png`);
+            expect(fsExtra.existsSync(result.filePath)).to.be.true;
         });
 
-        it('throws error when returnBuffer request fails', async () => {
+        it('throws error when request fails', async () => {
             let body = getFakeResponseBody(`
                 Shell.create('Roku.Message').trigger('Set message type', 'success').trigger('Set message content', 'Screenshot ok').trigger('Render', node);
 
@@ -3167,14 +3198,12 @@ describe('RokuDeploy', () => {
 
             onHandler = (event, callback) => {
                 if (event === 'response') {
-                    callback({
-                        statusCode: 500
-                    });
+                    callback({ statusCode: 500 });
                 }
             };
 
             mockDoPostRequest(body);
-            await expectThrowsAsync(rokuDeploy.captureScreenshot({ host: options.host, password: 'password', returnBuffer: true }));
+            await expectThrowsAsync(rokuDeploy.captureScreenshot({ host: options.host, password: 'password' }));
         });
     });
 

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -879,18 +879,10 @@ export class RokuDeploy {
 
     /**
      * Gets a screenshot from the device. A side-loaded channel must be running or an error will be thrown.
+     * Always returns an object with the screenshot buffer. If `out` is provided, also saves to disk.
      */
-    public async captureScreenshot(options: CaptureScreenshotOptions & { returnBuffer: true }): Promise<Buffer>;
-    public async captureScreenshot(options: CaptureScreenshotOptions): Promise<string>;
-    public async captureScreenshot(options: CaptureScreenshotOptions): Promise<string | Buffer> {
+    public async captureScreenshot(options: CaptureScreenshotOptions): Promise<CaptureScreenshotResult> {
         this.checkRequiredOptions(options, ['host', 'password']);
-        const cwd = options.cwd ?? process.cwd();
-        const screenshotDir = options.screenshotDir
-            ? path.resolve(cwd, options.screenshotDir)
-            : path.join(tempDir, '/roku-deploy/screenshots/');
-
-        // Track if user provided output path
-        const userProvidedOut = options.out !== undefined;
 
         // Ask for the device to make an image
         let createScreenshotResult = await this.doPostRequest({
@@ -910,39 +902,48 @@ export class RokuDeploy {
 
         const requestParams = this.generateBaseRequestOptions(imageUrlOnDevice, options);
 
-        // If returnBuffer is true, return the image as a Buffer
-        if (options.returnBuffer) {
-            return this.downloadToBuffer(requestParams);
-        }
+        // Always download to buffer
+        const buffer = await this.downloadToBuffer(requestParams);
 
-        // Determine output path
-        let out: string;
-        if (userProvidedOut) {
-            out = path.resolve(cwd, options.out);
-            const userExt = path.extname(out).toLowerCase();
-            const deviceExtLower = deviceExt.toLowerCase();
+        const result: CaptureScreenshotResult = { buffer };
 
-            if (options.autoExtension) {
-                // Smart extension handling when autoExtension is enabled
-                if (userExt === deviceExtLower) {
-                    // User extension matches device extension - use as-is
-                } else if (userExt === '.jpg' || userExt === '.jpeg' || userExt === '.png') {
-                    // User provided an image extension that doesn't match - swap it
-                    out = out.slice(0, -userExt.length) + deviceExt;
-                } else {
-                    // No recognized image extension - append device extension
-                    out += deviceExt;
+        // If out is provided, also save to disk
+        if (options.out) {
+            const cwd = options.cwd ?? process.cwd();
+            const screenshotDir = options.screenshotDir
+                ? path.resolve(cwd, options.screenshotDir)
+                : path.join(tempDir, '/roku-deploy/screenshots/');
+
+            let filePath: string;
+            if (options.out === true) {
+                // Use default directory with generated filename
+                const defaultFilename = `screenshot-${dayjs().format('YYYY-MM-DD-HH.mm.ss.SSS')}${deviceExt}`;
+                filePath = path.resolve(cwd, screenshotDir, defaultFilename);
+            } else {
+                // User provided a path
+                filePath = path.resolve(cwd, options.out);
+                const userExt = path.extname(filePath).toLowerCase();
+                const deviceExtLower = deviceExt.toLowerCase();
+
+                if (options.autoExtension) {
+                    if (userExt === deviceExtLower) {
+                        // User extension matches device extension - use as-is
+                    } else if (userExt === '.jpg' || userExt === '.jpeg' || userExt === '.png') {
+                        // User provided an image extension that doesn't match - swap it
+                        filePath = filePath.slice(0, -userExt.length) + deviceExt;
+                    } else {
+                        // No recognized image extension - append device extension
+                        filePath += deviceExt;
+                    }
                 }
             }
-            // else: use exactly as provided
-        } else {
-            // No user-provided path - use default directory with generated filename
-            const defaultFilename = `screenshot-${dayjs().format('YYYY-MM-DD-HH.mm.ss.SSS')}${deviceExt}`;
-            out = path.resolve(cwd, screenshotDir, defaultFilename);
+
+            await fsExtra.ensureFile(filePath);
+            await fsExtra.writeFile(filePath, buffer);
+            result.filePath = filePath;
         }
 
-        await this.downloadFile(requestParams, out);
-        return out;
+        return result;
     }
 
     private async downloadFile(requestParams: any, filePath: string) {
@@ -1252,10 +1253,11 @@ export interface HttpResponse {
 
 export interface CaptureScreenshotOptions extends BaseRequestOptions {
     /**
-     * The output screenshot file path (e.g., './screenshots/capture.jpg')
-     * Will use the OS temp directory with auto-generated filename by default
+     * When provided, saves the screenshot to disk in addition to returning the buffer.
+     * - If `true`, saves to the default location (screenshotDir or OS temp directory)
+     * - If a string path, saves to that location
      */
-    out?: string;
+    out?: string | true;
 
     /**
      * The current working directory to use for relative paths
@@ -1263,7 +1265,7 @@ export interface CaptureScreenshotOptions extends BaseRequestOptions {
     cwd?: string;
 
     /**
-     * The directory where screenshots should be saved when no `out` path is specified.
+     * The directory where screenshots should be saved when `out` is `true`.
      * Defaults to the OS temp directory.
      */
     screenshotDir?: string;
@@ -1277,13 +1279,17 @@ export interface CaptureScreenshotOptions extends BaseRequestOptions {
      * @default false
      */
     autoExtension?: boolean;
+}
 
+export interface CaptureScreenshotResult {
     /**
-     * When true, returns the screenshot as a Buffer instead of writing to disk.
-     * The `out` and `screenshotDir` options are ignored when this is true.
-     * @default false
+     * The screenshot image data
      */
-    returnBuffer?: boolean;
+    buffer: Buffer;
+    /**
+     * The file path where the screenshot was saved (only present when `out` option was provided)
+     */
+    filePath?: string;
 }
 
 export interface GetDeviceInfoOptions extends BaseEcpOptions {

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -905,7 +905,7 @@ export class RokuDeploy {
         // Always download to buffer
         const buffer = await this.downloadToBuffer(requestParams);
 
-        const result: CaptureScreenshotResult = { buffer };
+        const result: CaptureScreenshotResult = { buffer: buffer };
 
         // If out is provided, also save to disk
         if (options.out) {

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -880,7 +880,9 @@ export class RokuDeploy {
     /**
      * Gets a screenshot from the device. A side-loaded channel must be running or an error will be thrown.
      */
-    public async captureScreenshot(options: CaptureScreenshotOptions) {
+    public async captureScreenshot(options: CaptureScreenshotOptions & { returnBuffer: true }): Promise<Buffer>;
+    public async captureScreenshot(options: CaptureScreenshotOptions): Promise<string>;
+    public async captureScreenshot(options: CaptureScreenshotOptions): Promise<string | Buffer> {
         this.checkRequiredOptions(options, ['host', 'password']);
         const cwd = options.cwd ?? process.cwd();
         const screenshotDir = options.screenshotDir
@@ -904,6 +906,13 @@ export class RokuDeploy {
 
         if (!imageUrlOnDevice) {
             throw new Error('No screenshot url returned from device');
+        }
+
+        const requestParams = this.generateBaseRequestOptions(imageUrlOnDevice, options);
+
+        // If returnBuffer is true, return the image as a Buffer
+        if (options.returnBuffer) {
+            return this.downloadToBuffer(requestParams);
         }
 
         // Determine output path
@@ -932,10 +941,7 @@ export class RokuDeploy {
             out = path.resolve(cwd, screenshotDir, defaultFilename);
         }
 
-        await this.downloadFile(
-            this.generateBaseRequestOptions(imageUrlOnDevice, options),
-            out
-        );
+        await this.downloadFile(requestParams, out);
         return out;
     }
 
@@ -971,6 +977,27 @@ export class RokuDeploy {
             try {
                 writeStream.close();
             } catch { }
+        });
+    }
+
+    private downloadToBuffer(requestParams: any): Promise<Buffer> {
+        return new Promise<Buffer>((resolve, reject) => {
+            const chunks: Buffer[] = [];
+            request.get(requestParams)
+                .on('error', (err) => {
+                    reject(err);
+                })
+                .on('response', (response) => {
+                    if (response.statusCode !== 200) {
+                        return reject(new Error('Invalid response code: ' + response.statusCode));
+                    }
+                })
+                .on('data', (chunk: Buffer) => {
+                    chunks.push(chunk);
+                })
+                .on('end', () => {
+                    resolve(Buffer.concat(chunks));
+                });
         });
     }
 
@@ -1250,6 +1277,13 @@ export interface CaptureScreenshotOptions extends BaseRequestOptions {
      * @default false
      */
     autoExtension?: boolean;
+
+    /**
+     * When true, returns the screenshot as a Buffer instead of writing to disk.
+     * The `out` and `screenshotDir` options are ignored when this is true.
+     * @default false
+     */
+    returnBuffer?: boolean;
 }
 
 export interface GetDeviceInfoOptions extends BaseEcpOptions {

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -148,7 +148,7 @@ describe('cli', function cli() {
 
     it('Takes a screenshot', async () => {
         const stub = sinon.stub(rokuDeploy, 'captureScreenshot').callsFake(async () => {
-            return Promise.resolve('');
+            return Promise.resolve({ buffer: Buffer.from(''), filePath: '' });
         });
 
         const command = new CaptureScreenshotCommand();


### PR DESCRIPTION
Adds returnBuffer option to captureScreenshot() that returns a Buffer instead of writing to disk.

  Closes #172                                                                                                        
   
  ---                                                                                                                
  API                                                      
                                                          
```typescript
  // Existing behavior - returns file path
  const path = await rokuDeploy.captureScreenshot({ host, password });


  // New behavior - returns Buffer
  const buffer = await rokuDeploy.captureScreenshot({ host, password, returnBuffer: true });
```

  ---
  ### Why Overloads?

  TypeScript overloads provide proper return type inference based on the options passed:

  ```typescript
// TypeScript knows this is Promise<Buffer>
  const buffer = await captureScreenshot({ host, password, returnBuffer: true });

  // TypeScript knows this is Promise<string>
  const path = await captureScreenshot({ host, password });
```

  Without overloads, the return type would be Promise<string | Buffer>, requiring users to narrow the type manually:

```typescript
  // Without overloads - awkward
  const result = await captureScreenshot({ host, password, returnBuffer: true });
  if (Buffer.isBuffer(result)) {
    // now we can use it as Buffer
  }
```

  This pattern follows the existing convention in the codebase (see `getDeviceInfo()` with its enhance option).