### PR TITLE
Unified device option

### DIFF
--- a/src/DeviceConfig.ts
+++ b/src/DeviceConfig.ts
@@ -1,0 +1,91 @@
+// === Local Device ===
+
+/**
+ * Configuration for a local network device (IP, hostname, domain, or *.local)
+ */
+export interface LocalDeviceConfig {
+    host: string;
+}
+
+// === RCE Device Variants ===
+
+/**
+ * Configuration for an RCE device addressed by ESN
+ */
+export interface RceDeviceConfigByEsn {
+    esn: string;
+    rceToken?: string;
+}
+
+/**
+ * Configuration for an RCE device addressed by device ID
+ */
+export interface RceDeviceConfigById {
+    id: string;
+    rceToken?: string;
+}
+
+/**
+ * Configuration for an RCE device addressed by instance URL
+ */
+export interface RceDeviceConfigByUrl {
+    instanceUrl: string;
+    rceToken?: string;
+}
+
+/**
+ * Configuration for any RCE (Roku Cloud Emulator) device
+ */
+export type RceDeviceConfig =
+    | RceDeviceConfigByEsn
+    | RceDeviceConfigById
+    | RceDeviceConfigByUrl;
+
+/**
+ * Configuration specifying how to connect to a device.
+ * Either a local network device or an RCE device.
+ */
+export type DeviceConfig = LocalDeviceConfig | RceDeviceConfig;
+
+/**
+ * What the user provides as a device option.
+ * Either a registry name (string) or an inline device config.
+ */
+export type DeviceOption = string | DeviceConfig;
+
+// === Type Guards ===
+
+/**
+ * Check if a device config is for a local network device
+ */
+export function isLocalDeviceConfig(config: DeviceConfig): config is LocalDeviceConfig {
+    return 'host' in config;
+}
+
+/**
+ * Check if a device config is for an RCE device
+ */
+export function isRceDeviceConfig(config: DeviceConfig): config is RceDeviceConfig {
+    return 'esn' in config || 'id' in config || 'instanceUrl' in config;
+}
+
+/**
+ * Check if an RCE config is addressed by ESN
+ */
+export function isRceByEsn(config: RceDeviceConfig): config is RceDeviceConfigByEsn {
+    return 'esn' in config;
+}
+
+/**
+ * Check if an RCE config is addressed by device ID
+ */
+export function isRceById(config: RceDeviceConfig): config is RceDeviceConfigById {
+    return 'id' in config;
+}
+
+/**
+ * Check if an RCE config is addressed by instance URL
+ */
+export function isRceByUrl(config: RceDeviceConfig): config is RceDeviceConfigByUrl {
+    return 'instanceUrl' in config;
+}

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -37,7 +37,7 @@ describe('RokuDeploy', () => {
             devId: 'abcde',
             out: `${outDir}/roku-deploy.zip`,
             signingPassword: '12345',
-            host: 'localhost',
+            device: { host: 'localhost' },
             pkg: `${tempDir}/testSignedPackage.pkg`
         } as any;
         fsExtra.emptyDirSync(tempDir);
@@ -364,7 +364,7 @@ describe('RokuDeploy', () => {
 
         it('should return device info matching what was returned by ECP', async () => {
             mockDoGetRequest(body);
-            const deviceInfo = await rokuDeploy.getDeviceInfo({ host: '1.1.1.1' });
+            const deviceInfo = await rokuDeploy.getDeviceInfo({ device: { host: '1.1.1.1' } });
             expect(deviceInfo['serial-number']).to.equal('123');
             expect(deviceInfo['device-id']).to.equal('456');
             expect(deviceInfo['keyed-developer-id']).to.equal('789');
@@ -372,13 +372,13 @@ describe('RokuDeploy', () => {
 
         it('should default to port 8060 if not provided', async () => {
             const stub = mockDoGetRequest(body);
-            await rokuDeploy.getDeviceInfo({ host: '1.1.1.1' });
+            await rokuDeploy.getDeviceInfo({ device: { host: '1.1.1.1' } });
             expect(stub.getCall(0).args[0].url).to.eql('http://1.1.1.1:8060/query/device-info');
         });
 
         it('should use given port if provided', async () => {
             const stub = mockDoGetRequest(body);
-            await rokuDeploy.getDeviceInfo({ host: '1.1.1.1', ecpPort: 9999 });
+            await rokuDeploy.getDeviceInfo({ device: { host: '1.1.1.1' }, ecpPort: 9999 });
             expect(stub.getCall(0).args[0].url).to.eql('http://1.1.1.1:9999/query/device-info');
         });
 
@@ -389,7 +389,7 @@ describe('RokuDeploy', () => {
                     <udn>29380007-0800-1025-80a4-d83154332d7e</udn>
                 </device-info>
                 `);
-            const result = await rokuDeploy.getDeviceInfo({ host: '192.168.1.10', ecpPort: 8060, enhance: true });
+            const result = await rokuDeploy.getDeviceInfo({ device: { host: '192.168.1.10' }, ecpPort: 8060, enhance: true });
             expect(result.isStick).not.to.exist;
         });
 
@@ -399,13 +399,13 @@ describe('RokuDeploy', () => {
                     <has-mobile-screensaver>true</has-mobile-screensaver>
                 </device-info>
                 `);
-            const result = await rokuDeploy.getDeviceInfo({ host: '192.168.1.10' });
+            const result = await rokuDeploy.getDeviceInfo({ device: { host: '192.168.1.10' } });
             expect(result['has-mobile-screensaver']).to.eql('true');
         });
 
         it('should sanitize additional data when the host+param+format signature is triggered', async () => {
             mockDoGetRequest(body);
-            const result = await rokuDeploy.getDeviceInfo({ host: '192.168.1.10', ecpPort: 8060, enhance: true });
+            const result = await rokuDeploy.getDeviceInfo({ device: { host: '192.168.1.10' }, ecpPort: 8060, enhance: true });
             expect(result).to.include({
                 // make sure the number fields are turned into numbers
                 softwareBuild: 4170,
@@ -444,7 +444,7 @@ describe('RokuDeploy', () => {
 
         it('converts keys to camel case when enabled', async () => {
             mockDoGetRequest(body);
-            const result = await rokuDeploy.getDeviceInfo({ host: '192.168.1.10', ecpPort: 8060, enhance: true });
+            const result = await rokuDeploy.getDeviceInfo({ device: { host: '192.168.1.10' }, ecpPort: 8060, enhance: true });
             const props = [
                 'udn',
                 'serialNumber',
@@ -527,7 +527,7 @@ describe('RokuDeploy', () => {
         it('should throw our error on failure', async () => {
             mockDoGetRequest();
             try {
-                await rokuDeploy.getDeviceInfo({ host: '1.1.1.1' });
+                await rokuDeploy.getDeviceInfo({ device: { host: '1.1.1.1' } });
             } catch (e) {
                 expect(e).to.be.instanceof(errors.UnparsableDeviceResponseError);
                 return;
@@ -543,7 +543,7 @@ describe('RokuDeploy', () => {
                 httpDetails: { response: { headers: { server: 'Roku' } } }
             }));
             try {
-                await rokuDeploy.getDeviceInfo({ host: '1.1.1.1' });
+                await rokuDeploy.getDeviceInfo({ device: { host: '1.1.1.1' } });
                 assert.fail('Exception should have been thrown');
             } catch (e) {
                 expect(e).to.be.instanceof(errors.EcpNetworkAccessModeDisabledError);
@@ -554,7 +554,7 @@ describe('RokuDeploy', () => {
                 httpDetails: { response: { headers: { server: 'Apache' } } }
             }));
             try {
-                await rokuDeploy.getDeviceInfo({ host: '1.1.1.1' });
+                await rokuDeploy.getDeviceInfo({ device: { host: '1.1.1.1' } });
                 assert.fail('Exception should have been thrown');
             } catch (e) {
                 expect((e as errors.InvalidDeviceResponseCodeError).details.httpDetails?.response?.headers?.server).to.equal('Apache');
@@ -565,7 +565,7 @@ describe('RokuDeploy', () => {
                 httpDetails: { response: { headers: {} } }
             }));
             try {
-                await rokuDeploy.getDeviceInfo({ host: '1.1.1.1' });
+                await rokuDeploy.getDeviceInfo({ device: { host: '1.1.1.1' } });
                 assert.fail('Exception should have been thrown');
             } catch (e) {
                 expect((e as errors.InvalidDeviceResponseCodeError).details.httpDetails?.response?.headers?.server).to.be.undefined;
@@ -576,7 +576,7 @@ describe('RokuDeploy', () => {
                 httpDetails: { response: { headers: { server: null as any } } }
             }));
             try {
-                await rokuDeploy.getDeviceInfo({ host: '1.1.1.1' });
+                await rokuDeploy.getDeviceInfo({ device: { host: '1.1.1.1' } });
                 assert.fail('Exception should have been thrown');
             } catch (e) {
                 expect((e as errors.InvalidDeviceResponseCodeError).details.httpDetails?.response?.headers?.server).to.be.null;
@@ -587,7 +587,7 @@ describe('RokuDeploy', () => {
                 httpDetails: { response: {} }
             }));
             try {
-                await rokuDeploy.getDeviceInfo({ host: '1.1.1.1' });
+                await rokuDeploy.getDeviceInfo({ device: { host: '1.1.1.1' } });
                 assert.fail('Exception should have been thrown');
             } catch (e) {
                 expect((e as errors.InvalidDeviceResponseCodeError).details.httpDetails?.response?.headers).to.be.undefined;
@@ -596,7 +596,7 @@ describe('RokuDeploy', () => {
             // Reject with an error that has no httpDetails
             doGetRequestStub.rejects(new errors.InvalidDeviceResponseCodeError('test', {}));
             try {
-                await rokuDeploy.getDeviceInfo({ host: '1.1.1.1' });
+                await rokuDeploy.getDeviceInfo({ device: { host: '1.1.1.1' } });
                 assert.fail('Exception should have been thrown');
             } catch (e) {
                 expect((e as errors.InvalidDeviceResponseCodeError).details.httpDetails).to.be.undefined;
@@ -605,7 +605,7 @@ describe('RokuDeploy', () => {
             // Reject with an empty object (not a proper error)
             doGetRequestStub.rejects({});
             try {
-                await rokuDeploy.getDeviceInfo({ host: '1.1.1.1' });
+                await rokuDeploy.getDeviceInfo({ device: { host: '1.1.1.1' } });
                 assert.fail('Exception should have been thrown');
             } catch (e) {
                 expect((e as any).details).to.be.undefined;
@@ -614,7 +614,7 @@ describe('RokuDeploy', () => {
             const err = new Error('Network error');
             doGetRequestStub.rejects(err);
             try {
-                await rokuDeploy.getDeviceInfo({ host: '1.1.1.1' });
+                await rokuDeploy.getDeviceInfo({ device: { host: '1.1.1.1' } });
                 assert.fail('Exception should have been thrown');
             } catch (e) {
                 expect(e).to.equal(err);
@@ -623,7 +623,7 @@ describe('RokuDeploy', () => {
             // eslint-disable-next-line prefer-promise-reject-errors
             doGetRequestStub.callsFake(() => Promise.reject(null));
             try {
-                await rokuDeploy.getDeviceInfo({ host: '1.1.1.1' });
+                await rokuDeploy.getDeviceInfo({ device: { host: '1.1.1.1' } });
                 assert.fail('Exception should have been thrown');
             } catch (e) {
                 expect(e).to.be.null;
@@ -631,15 +631,15 @@ describe('RokuDeploy', () => {
         });
 
         describe('constructor defaults', () => {
-            it('fails when host not provided in constructor or call', async () => {
+            it('fails when device not provided in constructor or call', async () => {
                 const rd = new RokuDeploy();
                 await expectThrowsAsync(async () => {
                     await rd.getDeviceInfo();
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
-            it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('uses constructor device when not provided in call', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 const stub = sinon.stub(rd as any, 'doGetRequest').resolves({ body: '<device-info></device-info>' });
                 sinon.stub(util, 'dnsLookup').resolves('constructor-host');
                 try {
@@ -648,18 +648,18 @@ describe('RokuDeploy', () => {
                 expect(stub.getCall(0).args[0].url).to.include('constructor-host');
             });
 
-            it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('call device overrides constructor device', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 const stub = sinon.stub(rd as any, 'doGetRequest').resolves({ body: '<device-info></device-info>' });
                 sinon.stub(util, 'dnsLookup').resolves('call-host');
                 try {
-                    await rd.getDeviceInfo({ host: 'call-host' });
+                    await rd.getDeviceInfo({ device: { host: 'call-host' } });
                 } catch (e) { /* ignore parse errors */ }
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
 
             it('uses constructor ecpPort when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'localhost', ecpPort: 9000 });
+                const rd = new RokuDeploy({ device: { host: 'localhost' }, ecpPort: 9000 });
                 const stub = sinon.stub(rd as any, 'doGetRequest').resolves({ body: '<device-info></device-info>' });
                 sinon.stub(util, 'dnsLookup').resolves('localhost');
                 try {
@@ -669,7 +669,7 @@ describe('RokuDeploy', () => {
             });
 
             it('call ecpPort overrides constructor ecpPort', async () => {
-                const rd = new RokuDeploy({ host: 'localhost', ecpPort: 9000 });
+                const rd = new RokuDeploy({ device: { host: 'localhost' }, ecpPort: 9000 });
                 const stub = sinon.stub(rd as any, 'doGetRequest').resolves({ body: '<device-info></device-info>' });
                 sinon.stub(util, 'dnsLookup').resolves('localhost');
                 try {
@@ -683,7 +683,7 @@ describe('RokuDeploy', () => {
     describe('getEcpNetworkAccessMode', () => {
         it('returns ecpSettingMode from device info', async () => {
             sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({ 'ecp-setting-mode': 'enabled' } as any);
-            const result = await rokuDeploy.getEcpNetworkAccessMode({ host: '1.1.1.1' });
+            const result = await rokuDeploy.getEcpNetworkAccessMode({ device: { host: '1.1.1.1' } });
             expect(result).to.equal('enabled');
         });
 
@@ -693,7 +693,7 @@ describe('RokuDeploy', () => {
             getDeviceInfoStub.rejects(new errors.InvalidDeviceResponseCodeError('test', {
                 httpDetails: { response: { headers: { server: 'Roku' } } }
             }));
-            expect(await rokuDeploy.getEcpNetworkAccessMode({ host: '1.1.1.1' })).to.equal('disabled');
+            expect(await rokuDeploy.getEcpNetworkAccessMode({ device: { host: '1.1.1.1' } })).to.equal('disabled');
         });
 
         it('handles all error scenarios in catch block', async () => {
@@ -701,7 +701,7 @@ describe('RokuDeploy', () => {
             async function doTest(rejectionValue: any) {
                 getDeviceInfoStub.rejects(rejectionValue);
                 try {
-                    await rokuDeploy.getEcpNetworkAccessMode({ host: '1.1.1.1' });
+                    await rokuDeploy.getEcpNetworkAccessMode({ device: { host: '1.1.1.1' } });
                     assert.fail('Exception should have been thrown');
                 } catch (e) {
                     expect(e).to.be.instanceof(errors.UnknownDeviceResponseError);
@@ -722,7 +722,7 @@ describe('RokuDeploy', () => {
             const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo');
             getDeviceInfoStub.callsFake(() => Promise.reject(null));
             try {
-                await rokuDeploy.getEcpNetworkAccessMode({ host: '1.1.1.1' });
+                await rokuDeploy.getEcpNetworkAccessMode({ device: { host: '1.1.1.1' } });
                 assert.fail('Exception should have been thrown');
             } catch (e) {
                 expect(e).to.be.instanceof(errors.UnknownDeviceResponseError);
@@ -796,8 +796,8 @@ describe('RokuDeploy', () => {
             </device-info>`;
 
             mockDoGetRequest(deviceInfoBody);
-            const enhanced = await rokuDeploy.getDeviceInfo({ host: '192.168.1.10', ecpPort: 8060, enhance: true });
-            const raw = await rokuDeploy.getDeviceInfo({ host: '192.168.1.10', ecpPort: 8060 });
+            const enhanced = await rokuDeploy.getDeviceInfo({ device: { host: '192.168.1.10' }, ecpPort: 8060, enhance: true });
+            const raw = await rokuDeploy.getDeviceInfo({ device: { host: '192.168.1.10' }, ecpPort: 8060 });
 
             expect(rokuDeploy.enhanceDeviceInfo(raw)).to.eql(enhanced);
         });
@@ -816,31 +816,31 @@ describe('RokuDeploy', () => {
             </device-info>`;
             mockDoGetRequest(body);
             let { devId } = await rokuDeploy.getDevId({
-                host: '1.2.3.4'
+                device: { host: '1.2.3.4' }
             });
             expect(devId).to.equal(expectedDevId);
         });
 
         describe('constructor defaults', () => {
-            it('fails when host not provided in constructor or call', async () => {
+            it('fails when device not provided in constructor or call', async () => {
                 const rd = new RokuDeploy();
                 await expectThrowsAsync(async () => {
                     await rd.getDevId();
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
-            it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('uses constructor device when not provided in call', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 sinon.stub(rd, 'getDeviceInfo').resolves({ 'keyed-developer-id': 'abc123' } as any);
                 const { devId } = await rd.getDevId();
                 expect(devId).to.equal('abc123');
             });
 
-            it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('call device overrides constructor device', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 const stub = sinon.stub(rd, 'getDeviceInfo').resolves({ 'keyed-developer-id': 'abc123' } as any);
-                await rd.getDevId({ host: 'call-host' });
-                expect(stub.getCall(0).args[0].host).to.equal('call-host');
+                await rd.getDevId({ device: { host: 'call-host' } });
+                expect((stub.getCall(0).args[0] as any).device.host).to.equal('call-host');
             });
         });
     });
@@ -962,11 +962,11 @@ describe('RokuDeploy', () => {
 
     describe('generateBaseRequestOptions', () => {
         it('uses default port', () => {
-            expect(rokuDeploy['generateBaseRequestOptions']('a_b_c', { host: '1.2.3.4', password: 'password' }).url).to.equal('http://1.2.3.4:80/a_b_c');
+            expect(rokuDeploy['generateBaseRequestOptions']('a_b_c', '1.2.3.4', { device: { host: '1.2.3.4' }, password: 'password' }).url).to.equal('http://1.2.3.4:80/a_b_c');
         });
 
         it('uses overridden port', () => {
-            expect(rokuDeploy['generateBaseRequestOptions']('a_b_c', { host: '1.2.3.4', packagePort: 999, password: 'password' }).url).to.equal('http://1.2.3.4:999/a_b_c');
+            expect(rokuDeploy['generateBaseRequestOptions']('a_b_c', '1.2.3.4', { device: { host: '1.2.3.4' }, packagePort: 999, password: 'password' }).url).to.equal('http://1.2.3.4:999/a_b_c');
         });
     });
 
@@ -977,7 +977,7 @@ describe('RokuDeploy', () => {
                 process.nextTick(callback, new Error());
                 return {} as any;
             });
-            return rokuDeploy.keyPress({ ...options, host: '1.2.3.4', key: 'home' }).then(() => {
+            return rokuDeploy.keyPress({ ...options, device: { host: '1.2.3.4' }, key: 'home' }).then(() => {
                 assert.fail('Should have rejected the promise');
             }, () => {
                 expect(true).to.be.true;
@@ -991,7 +991,7 @@ describe('RokuDeploy', () => {
                     resolve();
                 });
             });
-            await rokuDeploy.keyPress({ ...options, host: '1.2.3.4', key: 'home' });
+            await rokuDeploy.keyPress({ ...options, device: { host: '1.2.3.4' }, key: 'home' });
             await promise;
         });
 
@@ -1002,7 +1002,7 @@ describe('RokuDeploy', () => {
                     resolve();
                 });
             });
-            await rokuDeploy.keyPress({ ...options, host: '1.2.3.4', ecpPort: 987, key: 'home' });
+            await rokuDeploy.keyPress({ ...options, device: { host: '1.2.3.4' }, ecpPort: 987, key: 'home' });
             await promise;
         });
 
@@ -1014,7 +1014,7 @@ describe('RokuDeploy', () => {
                     resolve();
                 });
             });
-            await rokuDeploy.keyPress({ ...options, host: '1.2.3.4', key: 'home' });
+            await rokuDeploy.keyPress({ ...options, device: { host: '1.2.3.4' }, key: 'home' });
             await promise;
         });
 
@@ -1027,7 +1027,7 @@ describe('RokuDeploy', () => {
                     resolve();
                 });
             });
-            await rokuDeploy.keyPress({ ...options, host: '1.2.3.4', ecpPort: 987, key: 'home', timeout: 1000 });
+            await rokuDeploy.keyPress({ ...options, device: { host: '1.2.3.4' }, ecpPort: 987, key: 'home', timeout: 1000 });
             await promise;
         });
     });
@@ -1038,20 +1038,20 @@ describe('RokuDeploy', () => {
                 const rd = new RokuDeploy();
                 await expectThrowsAsync(async () => {
                     await rd.keyPress({ key: 'home' } as any);
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
-            it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('uses constructor device when not provided in call', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
                 await rd.keyPress({ key: 'home' } as any);
                 expect(stub.getCall(0).args[0].url).to.include('constructor-host');
             });
 
-            it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('call device overrides constructor device', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
-                await rd.keyPress({ host: 'call-host', key: 'home' });
+                await rd.keyPress({ device: { host: 'call-host' }, key: 'home' });
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
         });
@@ -1059,24 +1059,24 @@ describe('RokuDeploy', () => {
 
     describe('keyUp', () => {
         describe('constructor defaults', () => {
-            it('fails when host not provided in constructor or call', async () => {
+            it('fails when device not provided in constructor or call', async () => {
                 const rd = new RokuDeploy();
                 await expectThrowsAsync(async () => {
                     await rd.keyUp({ key: 'home' } as any);
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
-            it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('uses constructor device when not provided in call', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
                 await rd.keyUp({ key: 'home' } as any);
                 expect(stub.getCall(0).args[0].url).to.include('constructor-host');
             });
 
-            it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('call device overrides constructor device', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
-                await rd.keyUp({ host: 'call-host', key: 'home' });
+                await rd.keyUp({ device: { host: 'call-host' }, key: 'home' });
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
         });
@@ -1084,24 +1084,24 @@ describe('RokuDeploy', () => {
 
     describe('keyDown', () => {
         describe('constructor defaults', () => {
-            it('fails when host not provided in constructor or call', async () => {
+            it('fails when device not provided in constructor or call', async () => {
                 const rd = new RokuDeploy();
                 await expectThrowsAsync(async () => {
                     await rd.keyDown({ key: 'home' } as any);
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
-            it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('uses constructor device when not provided in call', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
                 await rd.keyDown({ key: 'home' } as any);
                 expect(stub.getCall(0).args[0].url).to.include('constructor-host');
             });
 
-            it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('call device overrides constructor device', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
-                await rd.keyDown({ host: 'call-host', key: 'home' });
+                await rd.keyDown({ device: { host: 'call-host' }, key: 'home' });
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
         });
@@ -1109,24 +1109,24 @@ describe('RokuDeploy', () => {
 
     describe('sendText', () => {
         describe('constructor defaults', () => {
-            it('fails when host not provided in constructor or call', async () => {
+            it('fails when device not provided in constructor or call', async () => {
                 const rd = new RokuDeploy();
                 await expectThrowsAsync(async () => {
                     await rd.sendText({ text: 'a' } as any);
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
-            it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('uses constructor device when not provided in call', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
                 await rd.sendText({ text: 'a' } as any);
                 expect(stub.getCall(0).args[0].url).to.include('constructor-host');
             });
 
-            it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('call device overrides constructor device', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
-                await rd.sendText({ host: 'call-host', text: 'a' });
+                await rd.sendText({ device: { host: 'call-host' }, text: 'a' });
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
         });
@@ -1134,24 +1134,24 @@ describe('RokuDeploy', () => {
 
     describe('closeChannel', () => {
         describe('constructor defaults', () => {
-            it('fails when host not provided in constructor or call', async () => {
+            it('fails when device not provided in constructor or call', async () => {
                 const rd = new RokuDeploy();
                 await expectThrowsAsync(async () => {
                     await rd.closeChannel({} as any);
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
-            it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('uses constructor device when not provided in call', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
                 await rd.closeChannel({} as any);
                 expect(stub.getCall(0).args[0].url).to.include('constructor-host');
             });
 
-            it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host' });
+            it('call device overrides constructor device', async () => {
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
-                await rd.closeChannel({ host: 'call-host' });
+                await rd.closeChannel({ device: { host: 'call-host' } });
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
         });
@@ -1171,7 +1171,7 @@ describe('RokuDeploy', () => {
         it('uses overridden route', async () => {
             const stub = mockDoPostRequest();
             await rokuDeploy.sideload({
-                host: '0.0.0.0',
+                device: { host: '0.0.0.0' },
                 password: 'password',
                 zip: zipFile,
                 close: false,
@@ -1185,7 +1185,7 @@ describe('RokuDeploy', () => {
         it('overrides formData', async () => {
             const stub = mockDoPostRequest();
             await rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 remoteDebug: true,
@@ -1208,7 +1208,7 @@ describe('RokuDeploy', () => {
             //the file should exist
             expect(fsExtra.pathExistsSync(zipFile)).to.be.true;
             await rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 close: false
@@ -1223,7 +1223,7 @@ describe('RokuDeploy', () => {
             //the file should exist (created in beforeEach)
             expect(fsExtra.pathExistsSync(zipFile)).to.be.true;
             await rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 dir: rootDir,
                 close: false
@@ -1250,7 +1250,7 @@ describe('RokuDeploy', () => {
             //the file should exist
             expect(fsExtra.pathExistsSync(zipFile)).to.be.true;
             await rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 dir: rootDir,
                 close: false
@@ -1263,7 +1263,7 @@ describe('RokuDeploy', () => {
             const missingZip = s`${outDir}/fileThatDoesNotExist.zip`;
             await expectThrowsAsync(async () => {
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     zip: missingZip,
                     deleteDevChannel: false,
@@ -1272,13 +1272,13 @@ describe('RokuDeploy', () => {
             }, `Cannot sideload because file does not exist at '${missingZip}'`);
         });
 
-        it('fails when no host is provided', () => {
+        it('fails when no device is provided', () => {
             expectPathNotExists('rokudeploy.json');
             return rokuDeploy.sideload({
-                host: undefined,
+                device: undefined,
                 password: 'password',
                 zip: zipFile
-            }).then(() => {
+            } as any).then(() => {
                 assert.fail('Should not have succeeded');
             }, () => {
                 expect(true).to.be.true;
@@ -1300,7 +1300,7 @@ describe('RokuDeploy', () => {
 
             try {
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     zip: zipFile,
                     close: false
@@ -1319,7 +1319,7 @@ describe('RokuDeploy', () => {
             `);
 
             return rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 failOnCompileError: true,
@@ -1338,7 +1338,7 @@ describe('RokuDeploy', () => {
             `);
 
             return rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 failOnCompileError: true,
@@ -1355,7 +1355,7 @@ describe('RokuDeploy', () => {
             mockDoPostRequest(body);
 
             return rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 failOnCompileError: true,
@@ -1387,7 +1387,7 @@ describe('RokuDeploy', () => {
             mockDoPostRequest('', 401);
 
             return rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 failOnCompileError: true,
@@ -1407,7 +1407,7 @@ describe('RokuDeploy', () => {
             try {
                 await rokuDeploy.sideload(
                     {
-                        host: '1.2.3.4',
+                        device: { host: '1.2.3.4' },
                         password: 'password',
                         zip: zipFile,
                         close: false
@@ -1437,7 +1437,7 @@ describe('RokuDeploy', () => {
             try {
                 await rokuDeploy.sideload(
                     {
-                        host: '1.2.3.4',
+                        device: { host: '1.2.3.4' },
                         password: 'password',
                         zip: zipFile,
                         deleteDevChannel: false,
@@ -1469,7 +1469,7 @@ describe('RokuDeploy', () => {
             try {
                 await rokuDeploy.sideload(
                     {
-                        host: '1.2.3.4',
+                        device: { host: '1.2.3.4' },
                         password: 'password',
                         zip: zipFile,
                         deleteDevChannel: false,
@@ -1489,7 +1489,7 @@ describe('RokuDeploy', () => {
             mockDoPostRequest();
 
             return rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 failOnCompileError: true,
@@ -1505,7 +1505,7 @@ describe('RokuDeploy', () => {
             const stub = mockDoPostRequest();
 
             return rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 failOnCompileError: true,
@@ -1524,7 +1524,7 @@ describe('RokuDeploy', () => {
             const stub = mockDoPostRequest();
 
             return rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 failOnCompileError: true,
@@ -1547,7 +1547,7 @@ describe('RokuDeploy', () => {
             fsExtra.outputFileSync(zipFile, 'asdf');
 
             const result = await rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 deleteDevChannel: false,
@@ -1562,7 +1562,7 @@ describe('RokuDeploy', () => {
             fsExtra.outputFileSync(zipFile, 'asdf');
 
             const result = await rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 deleteDevChannel: false,
@@ -1578,7 +1578,7 @@ describe('RokuDeploy', () => {
             fsExtra.outputFileSync(zipFile, 'asdf');
 
             const result = await rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 deleteDevChannel: false,
@@ -1594,7 +1594,7 @@ describe('RokuDeploy', () => {
             fsExtra.outputFileSync(zipFile, 'asdf');
 
             const result = await rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 deleteDevChannel: false,
@@ -1610,7 +1610,7 @@ describe('RokuDeploy', () => {
             options.failOnCompileError = false;
 
             const result = await rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 failOnCompileError: true,
@@ -1628,7 +1628,7 @@ describe('RokuDeploy', () => {
 
             const result = await rokuDeploy.sideload({
                 appType: null,
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 failOnCompileError: true,
@@ -1646,7 +1646,7 @@ describe('RokuDeploy', () => {
 
             const result = await rokuDeploy.sideload({
                 appType: 'channel',
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 failOnCompileError: true,
@@ -1664,7 +1664,7 @@ describe('RokuDeploy', () => {
 
             const result = await rokuDeploy.sideload({
                 appType: 'dcl',
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 failOnCompileError: true,
@@ -1682,7 +1682,7 @@ describe('RokuDeploy', () => {
             mockDoPostRequest(body);
 
             return rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipFile,
                 failOnCompileError: false,
@@ -1700,7 +1700,7 @@ describe('RokuDeploy', () => {
 
             try {
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     failOnCompileError: true,
                     zip: zipFile,
@@ -1718,7 +1718,7 @@ describe('RokuDeploy', () => {
 
             try {
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     failOnCompileError: true,
                     zip: zipFile,
@@ -1736,7 +1736,7 @@ describe('RokuDeploy', () => {
 
             try {
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     failOnCompileError: true,
                     zip: zipFile,
@@ -1755,7 +1755,7 @@ describe('RokuDeploy', () => {
 
             try {
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     zip: zipFile,
                     deleteDevChannel: false,
@@ -1785,7 +1785,7 @@ describe('RokuDeploy', () => {
 
             try {
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     zip: zipFile,
                     deleteDevChannel: false,
@@ -1817,7 +1817,7 @@ describe('RokuDeploy', () => {
 
             try {
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     zip: zipFile,
                     close: false
@@ -1843,7 +1843,7 @@ describe('RokuDeploy', () => {
 
             try {
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     zip: zipFile,
                     close: false
@@ -1871,7 +1871,7 @@ describe('RokuDeploy', () => {
 
             try {
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     zip: zipFile,
                     close: false
@@ -1891,7 +1891,7 @@ describe('RokuDeploy', () => {
 
             try {
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     zip: zipFile,
                     close: false
@@ -1910,7 +1910,7 @@ describe('RokuDeploy', () => {
             fsExtra.outputFileSync(zipPath, 'zip contents');
 
             const result = await rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipPath,
                 close: false
@@ -1925,7 +1925,7 @@ describe('RokuDeploy', () => {
             fsExtra.outputFileSync(zipPath, 'zip contents');
 
             await rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipPath
             });
@@ -1939,7 +1939,7 @@ describe('RokuDeploy', () => {
             fsExtra.outputFileSync(zipPath, 'zip contents');
 
             await rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 zip: zipPath,
                 close: false
@@ -1957,7 +1957,7 @@ describe('RokuDeploy', () => {
             sinon.stub(rokuDeploy, 'closeChannel').resolves();
 
             await rokuDeploy.sideload({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 dir: rootDir
             });
@@ -1967,7 +1967,7 @@ describe('RokuDeploy', () => {
         it('fails when no password is provided', async () => {
             await expectThrowsAsync(async () => {
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: undefined,
                     zip: zipFile
                 });
@@ -1979,18 +1979,18 @@ describe('RokuDeploy', () => {
                 const rd = new RokuDeploy({ password: 'pass' });
                 await expectThrowsAsync(async () => {
                     await rd.sideload({ zip: 'test.zip' } as any);
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
             it('fails when password not provided in constructor or call', async () => {
-                const rd = new RokuDeploy({ host: 'localhost' });
+                const rd = new RokuDeploy({ device: { host: 'localhost' } });
                 await expectThrowsAsync(async () => {
                     await rd.sideload({ zip: 'test.zip' } as any);
                 }, 'Missing required option: password');
             });
 
             it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 sinon.stub(rd, 'deleteDevChannel').resolves();
                 sinon.stub(rd, 'closeChannel').resolves();
                 sinon.stub(fsExtra, 'pathExists').resolves(true);
@@ -2001,18 +2001,18 @@ describe('RokuDeploy', () => {
             });
 
             it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 sinon.stub(rd, 'deleteDevChannel').resolves();
                 sinon.stub(rd, 'closeChannel').resolves();
                 sinon.stub(fsExtra, 'pathExists').resolves(true);
                 sinon.stub(fsExtra, 'createReadStream').returns({ close: () => { }, on: (event, cb) => cb() } as any);
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: 'success', response: { statusCode: 200 } });
-                await rd.sideload({ host: 'call-host', zip: 'test.zip' } as any);
+                await rd.sideload({ device: { host: 'call-host' }, zip: 'test.zip' } as any);
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
 
             it('uses constructor password when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'localhost', password: 'constructor-pass' });
+                const rd = new RokuDeploy({ device: { host: 'localhost' }, password: 'constructor-pass' });
                 sinon.stub(rd, 'deleteDevChannel').resolves();
                 sinon.stub(rd, 'closeChannel').resolves();
                 sinon.stub(fsExtra, 'pathExists').resolves(true);
@@ -2023,7 +2023,7 @@ describe('RokuDeploy', () => {
             });
 
             it('call password overrides constructor password', async () => {
-                const rd = new RokuDeploy({ host: 'localhost', password: 'constructor-pass' });
+                const rd = new RokuDeploy({ device: { host: 'localhost' }, password: 'constructor-pass' });
                 sinon.stub(rd, 'deleteDevChannel').resolves();
                 sinon.stub(rd, 'closeChannel').resolves();
                 sinon.stub(fsExtra, 'pathExists').resolves(true);
@@ -2041,7 +2041,7 @@ describe('RokuDeploy', () => {
 
                 const zipSize = fsExtra.statSync(zipFile).size;
                 await expectThrowsAsync(
-                    rokuDeploy.sideload({ host: '1.2.3.4', password: 'password', zip: zipFile, close: false }),
+                    rokuDeploy.sideload({ device: { host: '1.2.3.4' }, password: 'password', zip: zipFile, close: false }),
                     `Failed to publish: Install Failure: Unzip failed. Invalid or corrupt zip archive. ` +
                     `The supplied zip is ${zipSize} bytes, and zips smaller than ${RokuDeploy.MINIMUM_INSTALLABLE_ZIP_SIZE} bytes often cause this.`
                 );
@@ -2055,7 +2055,7 @@ describe('RokuDeploy', () => {
                 const zipSize = fsExtra.statSync(zipFile).size;
                 let thrown: Error;
                 try {
-                    await rokuDeploy.sideload({ host: '1.2.3.4', password: 'password', zip: zipFile, close: false });
+                    await rokuDeploy.sideload({ device: { host: '1.2.3.4' }, password: 'password', zip: zipFile, close: false });
                 } catch (e) {
                     thrown = e as Error;
                 }
@@ -2073,7 +2073,7 @@ describe('RokuDeploy', () => {
                 const zipSize = fsExtra.statSync(zipFile).size;
                 let thrown: Error;
                 try {
-                    await rokuDeploy.sideload({ host: '1.2.3.4', password: 'password', zip: zipFile, close: false });
+                    await rokuDeploy.sideload({ device: { host: '1.2.3.4' }, password: 'password', zip: zipFile, close: false });
                 } catch (e) {
                     thrown = e as Error;
                 }
@@ -2088,7 +2088,7 @@ describe('RokuDeploy', () => {
 
                 let thrown: Error;
                 try {
-                    await rokuDeploy.sideload({ host: '1.2.3.4', password: 'password', zip: zipFile, close: false });
+                    await rokuDeploy.sideload({ device: { host: '1.2.3.4' }, password: 'password', zip: zipFile, close: false });
                 } catch (e) {
                     thrown = e as Error;
                 }
@@ -2103,7 +2103,7 @@ describe('RokuDeploy', () => {
 
                 let thrown: Error;
                 try {
-                    await rokuDeploy.sideload({ host: '1.2.3.4', password: 'password', zip: zipFile, close: false });
+                    await rokuDeploy.sideload({ device: { host: '1.2.3.4' }, password: 'password', zip: zipFile, close: false });
                 } catch (e) {
                     thrown = e as Error;
                 }
@@ -2116,7 +2116,7 @@ describe('RokuDeploy', () => {
                 mockDoPostRequest('Install Failure: Unzip failed. Invalid or corrupt zip archive.');
 
                 //no hint => the corrupt-zip body is not turned into a thrown error, so sideload resolves normally
-                const result = await rokuDeploy.sideload({ host: '1.2.3.4', password: 'password', zip: zipFile, close: false });
+                const result = await rokuDeploy.sideload({ device: { host: '1.2.3.4' }, password: 'password', zip: zipFile, close: false });
                 expect(result.message).to.equal('Successful sideload');
             });
 
@@ -2130,7 +2130,7 @@ describe('RokuDeploy', () => {
         it('should not return an error if successful', async () => {
             mockDoPostRequest('<font color="red">Conversion succeeded<p></p><code><br>Parallel mksquashfs: Using 1 processor');
             await rokuDeploy.convertToSquashfs({
-                host: options.host,
+                device: options.device,
                 password: 'password'
             });
         });
@@ -2139,7 +2139,7 @@ describe('RokuDeploy', () => {
             mockDoPostRequest();
             try {
                 await rokuDeploy.convertToSquashfs({
-                    host: options.host,
+                    device: options.device,
                     password: 'password'
                 });
             } catch (e) {
@@ -2158,7 +2158,7 @@ describe('RokuDeploy', () => {
             try {
                 await rokuDeploy.convertToSquashfs({
                     ...options,
-                    host: options.host,
+                    device: options.device,
                     password: 'password'
                 });
             } catch (e) {
@@ -2174,7 +2174,7 @@ describe('RokuDeploy', () => {
             try {
                 await rokuDeploy.convertToSquashfs({
                     ...options,
-                    host: options.host,
+                    device: options.device,
                     password: 'password'
                 });
             } catch (e) {
@@ -2194,7 +2194,7 @@ describe('RokuDeploy', () => {
             try {
                 await rokuDeploy.convertToSquashfs({
                     ...options,
-                    host: options.host,
+                    device: options.device,
                     password: 'password'
                 });
             } catch (e) {
@@ -2215,7 +2215,7 @@ describe('RokuDeploy', () => {
             try {
                 await rokuDeploy.convertToSquashfs({
                     ...options,
-                    host: options.host,
+                    device: options.device,
                     password: 'password'
                 });
             } catch (e) {
@@ -2230,27 +2230,27 @@ describe('RokuDeploy', () => {
                 const rd = new RokuDeploy({ password: 'pass' });
                 await expectThrowsAsync(async () => {
                     await rd.convertToSquashfs({} as any);
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
             it('fails when password not provided in constructor or call', async () => {
-                const rd = new RokuDeploy({ host: 'localhost' });
+                const rd = new RokuDeploy({ device: { host: 'localhost' } });
                 await expectThrowsAsync(async () => {
                     await rd.convertToSquashfs({} as any);
                 }, 'Missing required option: password');
             });
 
             it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: 'Conversion succeeded' });
                 await rd.convertToSquashfs({} as any);
                 expect(stub.getCall(0).args[0].url).to.include('constructor-host');
             });
 
             it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: 'Conversion succeeded' });
-                await rd.convertToSquashfs({ host: 'call-host' } as any);
+                await rd.convertToSquashfs({ device: { host: 'call-host' } } as any);
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
         });
@@ -2280,7 +2280,7 @@ describe('RokuDeploy', () => {
             let actualError: Error;
             try {
                 await rokuDeploy.rekeyDevice({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     pkg: options.pkg,
                     signingPassword: options.signingPassword,
@@ -2302,7 +2302,7 @@ describe('RokuDeploy', () => {
             //small sleep to ensure the file exists (hack for testing!)
             await util.sleep(10);
             await rokuDeploy.rekeyDevice({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 cwd: rootDir,
                 pkg: s`../notReal.pkg`,
@@ -2317,7 +2317,7 @@ describe('RokuDeploy', () => {
             </div>`;
             mockDoPostRequest(body);
             await rokuDeploy.rekeyDevice({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 pkg: s`${tempDir}/testSignedPackage.pkg`,
                 signingPassword: options.signingPassword,
@@ -2331,7 +2331,7 @@ describe('RokuDeploy', () => {
             </div>`;
             mockDoPostRequest(body);
             await rokuDeploy.rekeyDevice({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 pkg: options.pkg,
                 signingPassword: options.signingPassword,
@@ -2345,7 +2345,7 @@ describe('RokuDeploy', () => {
             </div>`;
             mockDoPostRequest(body);
             await rokuDeploy.rekeyDevice({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 pkg: options.pkg,
                 signingPassword: options.signingPassword,
@@ -2357,7 +2357,7 @@ describe('RokuDeploy', () => {
             try {
                 mockDoPostRequest();
                 await rokuDeploy.rekeyDevice({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     pkg: options.pkg,
                     signingPassword: options.signingPassword,
@@ -2377,7 +2377,7 @@ describe('RokuDeploy', () => {
                 </div>`;
                 mockDoPostRequest(body);
                 await rokuDeploy.rekeyDevice({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     pkg: options.pkg,
                     signingPassword: options.signingPassword,
@@ -2397,7 +2397,7 @@ describe('RokuDeploy', () => {
                 </div>`;
                 mockDoPostRequest(body);
                 await rokuDeploy.rekeyDevice({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     pkg: options.pkg,
                     signingPassword: options.signingPassword,
@@ -2415,18 +2415,18 @@ describe('RokuDeploy', () => {
                 const rd = new RokuDeploy({ password: 'pass' });
                 await expectThrowsAsync(async () => {
                     await rd.rekeyDevice({ pkg: 'test.pkg', signingPassword: 'sign' } as any);
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
             it('fails when password not provided in constructor or call', async () => {
-                const rd = new RokuDeploy({ host: 'localhost' });
+                const rd = new RokuDeploy({ device: { host: 'localhost' } });
                 await expectThrowsAsync(async () => {
                     await rd.rekeyDevice({ pkg: 'test.pkg', signingPassword: 'sign' } as any);
                 }, 'Missing required option: password');
             });
 
             it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '<font color="red">Success.</font>' });
                 sinon.stub(fsExtra, 'pathExists').resolves(true);
                 sinon.stub(fsExtra, 'createReadStream').returns({} as any);
@@ -2435,11 +2435,11 @@ describe('RokuDeploy', () => {
             });
 
             it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '<font color="red">Success.</font>' });
                 sinon.stub(fsExtra, 'pathExists').resolves(true);
                 sinon.stub(fsExtra, 'createReadStream').returns({} as any);
-                await rd.rekeyDevice({ host: 'call-host', pkg: 'test.pkg', signingPassword: 'sign' } as any);
+                await rd.rekeyDevice({ device: { host: 'call-host' }, pkg: 'test.pkg', signingPassword: 'sign' } as any);
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
         });
@@ -2485,7 +2485,7 @@ describe('RokuDeploy', () => {
                     return {} as any;
                 });
                 await rokuDeploy.createSignedPackage({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     signingPassword: options.signingPassword,
                     manifestPath: s`${tempDir}/manifest`
@@ -2501,7 +2501,7 @@ describe('RokuDeploy', () => {
             try {
                 mockDoPostRequest(null);
                 await rokuDeploy.createSignedPackage({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     signingPassword: options.signingPassword,
                     manifestPath: s`${tempDir}/manifest`
@@ -2522,7 +2522,7 @@ describe('RokuDeploy', () => {
 
             await expectThrowsAsync(
                 rokuDeploy.createSignedPackage({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     signingPassword: options.signingPassword,
                     manifestPath: s`${tempDir}/manifest`
@@ -2540,7 +2540,7 @@ describe('RokuDeploy', () => {
             const stub = sinon.stub(rokuDeploy as any, 'downloadFile').returns(Promise.resolve('pkgs//P6953175d5df120c0069c53de12515b9a.pkg'));
 
             let result = await rokuDeploy.createSignedPackage({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 signingPassword: options.signingPassword,
                 out: s`${outDir}/roku-deploy.pkg`,
@@ -2556,7 +2556,7 @@ describe('RokuDeploy', () => {
             const stub = sinon.stub(rokuDeploy as any, 'downloadFile').returns(Promise.resolve());
 
             let result = await rokuDeploy.createSignedPackage({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 signingPassword: options.signingPassword,
                 manifestPath: s`${tempDir}/manifest`,
@@ -2575,7 +2575,7 @@ describe('RokuDeploy', () => {
             const stub = sinon.stub(rokuDeploy as any, 'downloadFile').returns(Promise.resolve());
 
             let result = await rokuDeploy.createSignedPackage({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password',
                 signingPassword: options.signingPassword,
                 manifestPath: s`${tempDir}/manifest`,
@@ -2589,7 +2589,7 @@ describe('RokuDeploy', () => {
             mockDoPostRequest();
             await expectThrowsAsync(
                 rokuDeploy.createSignedPackage({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     signingPassword: options.signingPassword,
                     manifestPath: s`${tempDir}/manifest`
@@ -2606,7 +2606,7 @@ describe('RokuDeploy', () => {
                 `);
             await expectThrowsAsync(
                 rokuDeploy.createSignedPackage({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     signingPassword: options.signingPassword,
                     devId: '123',
@@ -2619,7 +2619,7 @@ describe('RokuDeploy', () => {
         it('should return error if neither manifestPath nor appTitle and appVersion are provided', async () => {
             await expectThrowsAsync(
                 rokuDeploy.createSignedPackage({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     signingPassword: options.signingPassword,
                     devId: '123'
@@ -2632,7 +2632,7 @@ describe('RokuDeploy', () => {
             fsExtra.outputFileSync(`${tempDir}/manifest`, `title=AwesomeApp`);
             await expectThrowsAsync(
                 rokuDeploy.createSignedPackage({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     signingPassword: options.signingPassword,
                     devId: '123',
@@ -2646,7 +2646,7 @@ describe('RokuDeploy', () => {
             fsExtra.outputFileSync(`${tempDir}/manifest`, `major_version=1\nminor_version=0`);
             await expectThrowsAsync(
                 rokuDeploy.createSignedPackage({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     signingPassword: options.signingPassword,
                     devId: '123',
@@ -2679,7 +2679,7 @@ describe('RokuDeploy', () => {
             let error: Error;
             try {
                 await rokuDeploy.createSignedPackage({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password',
                     signingPassword: options.signingPassword,
                     manifestPath: s`${tempDir}/manifest`
@@ -2704,7 +2704,7 @@ describe('RokuDeploy', () => {
 
             await expectThrowsAsync(
                 rokuDeploy.createSignedPackage({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'aaaa',
                     signingPassword: options.signingPassword,
                     manifestPath: s`${tempDir}/manifest`
@@ -2718,18 +2718,18 @@ describe('RokuDeploy', () => {
                 const rd = new RokuDeploy({ password: 'pass' });
                 await expectThrowsAsync(async () => {
                     await rd.createSignedPackage({ signingPassword: 'sign', appTitle: 'test', appVersion: '1.0.0' } as any);
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
             it('fails when password not provided in constructor or call', async () => {
-                const rd = new RokuDeploy({ host: 'localhost' });
+                const rd = new RokuDeploy({ device: { host: 'localhost' } });
                 await expectThrowsAsync(async () => {
                     await rd.createSignedPackage({ signingPassword: 'sign', appTitle: 'test', appVersion: '1.0.0' } as any);
                 }, 'Missing required option: password');
             });
 
             it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '<a href="pkgs/package.pkg">' });
                 sinon.stub(rd as any, 'downloadFile').resolves();
                 await rd.createSignedPackage({ signingPassword: 'sign', appTitle: 'test', appVersion: '1.0.0' } as any);
@@ -2737,10 +2737,10 @@ describe('RokuDeploy', () => {
             });
 
             it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '<a href="pkgs/package.pkg">' });
                 sinon.stub(rd as any, 'downloadFile').resolves();
-                await rd.createSignedPackage({ host: 'call-host', signingPassword: 'sign', appTitle: 'test', appVersion: '1.0.0' } as any);
+                await rd.createSignedPackage({ device: { host: 'call-host' }, signingPassword: 'sign', appTitle: 'test', appVersion: '1.0.0' } as any);
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
         });
@@ -3321,7 +3321,7 @@ describe('RokuDeploy', () => {
             mockGetDeviceInfo('15.0.4');
             let stub = mockDoPostRequest();
             let result = await rokuDeploy.rebootDevice({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password'
             });
             expect(result).not.to.be.undefined;
@@ -3333,7 +3333,7 @@ describe('RokuDeploy', () => {
             mockGetDeviceInfo('15.0.4');
             let stub = mockDoPostRequest();
             let result = await rokuDeploy.checkForUpdate({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password'
             });
             expect(result).not.to.be.undefined;
@@ -3345,7 +3345,7 @@ describe('RokuDeploy', () => {
             mockGetDeviceInfo('15.0.3');
             await assertThrowsAsync(async () => {
                 await rokuDeploy.rebootDevice({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password'
                 });
             });
@@ -3355,7 +3355,7 @@ describe('RokuDeploy', () => {
             mockGetDeviceInfo(null);
             await assertThrowsAsync(async () => {
                 await rokuDeploy.rebootDevice({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password'
                 });
             });
@@ -3365,7 +3365,7 @@ describe('RokuDeploy', () => {
             mockGetDeviceInfo('15.0.3');
             await assertThrowsAsync(async () => {
                 await rokuDeploy.checkForUpdate({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password'
                 });
             });
@@ -3375,7 +3375,7 @@ describe('RokuDeploy', () => {
             mockGetDeviceInfo(null);
             await assertThrowsAsync(async () => {
                 await rokuDeploy.checkForUpdate({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'password'
                 });
             });
@@ -3386,18 +3386,18 @@ describe('RokuDeploy', () => {
                 const rd = new RokuDeploy({ password: 'pass' });
                 await expectThrowsAsync(async () => {
                     await rd.rebootDevice({} as any);
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
             it('fails when password not provided in constructor or call', async () => {
-                const rd = new RokuDeploy({ host: 'localhost' });
+                const rd = new RokuDeploy({ device: { host: 'localhost' } });
                 await expectThrowsAsync(async () => {
                     await rd.rebootDevice({} as any);
                 }, 'Missing required option: password');
             });
 
             it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 sinon.stub(rd, 'getDeviceInfo').resolves({ 'software-version': '15.0.4' } as any);
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '' });
                 await rd.rebootDevice({} as any);
@@ -3405,10 +3405,10 @@ describe('RokuDeploy', () => {
             });
 
             it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 sinon.stub(rd, 'getDeviceInfo').resolves({ 'software-version': '15.0.4' } as any);
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '' });
-                await rd.rebootDevice({ host: 'call-host' } as any);
+                await rd.rebootDevice({ device: { host: 'call-host' } } as any);
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
         });
@@ -3418,18 +3418,18 @@ describe('RokuDeploy', () => {
                 const rd = new RokuDeploy({ password: 'pass' });
                 await expectThrowsAsync(async () => {
                     await rd.checkForUpdate({} as any);
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
             it('fails when password not provided in constructor or call', async () => {
-                const rd = new RokuDeploy({ host: 'localhost' });
+                const rd = new RokuDeploy({ device: { host: 'localhost' } });
                 await expectThrowsAsync(async () => {
                     await rd.checkForUpdate({} as any);
                 }, 'Missing required option: password');
             });
 
             it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 sinon.stub(rd, 'getDeviceInfo').resolves({ 'software-version': '15.0.4' } as any);
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '' });
                 await rd.checkForUpdate({} as any);
@@ -3437,10 +3437,10 @@ describe('RokuDeploy', () => {
             });
 
             it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 sinon.stub(rd, 'getDeviceInfo').resolves({ 'software-version': '15.0.4' } as any);
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '' });
-                await rd.checkForUpdate({ host: 'call-host' } as any);
+                await rd.checkForUpdate({ device: { host: 'call-host' } } as any);
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
         });
@@ -3451,7 +3451,7 @@ describe('RokuDeploy', () => {
             mockDoPostRequest();
 
             let result = await rokuDeploy.deleteDevChannel({
-                host: '1.2.3.4',
+                device: { host: '1.2.3.4' },
                 password: 'password'
             });
             expect(result).not.to.be.undefined;
@@ -3462,27 +3462,27 @@ describe('RokuDeploy', () => {
                 const rd = new RokuDeploy({ password: 'pass' });
                 await expectThrowsAsync(async () => {
                     await rd.deleteDevChannel();
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
             it('fails when password not provided in constructor or call', async () => {
-                const rd = new RokuDeploy({ host: 'localhost' });
+                const rd = new RokuDeploy({ device: { host: 'localhost' } });
                 await expectThrowsAsync(async () => {
                     await rd.deleteDevChannel();
                 }, 'Missing required option: password');
             });
 
             it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '', response: { statusCode: 200 } });
                 await rd.deleteDevChannel();
                 expect(stub.getCall(0).args[0].url).to.include('constructor-host');
             });
 
             it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '', response: { statusCode: 200 } });
-                await rd.deleteDevChannel({ host: 'call-host' } as any);
+                await rd.deleteDevChannel({ device: { host: 'call-host' } } as any);
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
         });
@@ -3531,19 +3531,19 @@ describe('RokuDeploy', () => {
             `);
 
             mockDoPostRequest(body);
-            await expectThrowsAsync(rokuDeploy.captureScreenshot({ host: options.host, password: 'password' }));
+            await expectThrowsAsync(rokuDeploy.captureScreenshot({ device: options.device, password: 'password' }));
         });
 
         it('throws when there is no response body', async () => {
             // missing body
             mockDoPostRequest(null);
-            await expectThrowsAsync(rokuDeploy.captureScreenshot({ host: options.host, password: 'password' }));
+            await expectThrowsAsync(rokuDeploy.captureScreenshot({ device: options.device, password: 'password' }));
         });
 
         it('throws when there is an empty response body', async () => {
             // empty body
             mockDoPostRequest();
-            await expectThrowsAsync(rokuDeploy.captureScreenshot({ host: options.host, password: 'password' }));
+            await expectThrowsAsync(rokuDeploy.captureScreenshot({ device: options.device, password: 'password' }));
         });
 
         it('throws when there is an error downloading the image from device', async () => {
@@ -3564,7 +3564,7 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            await expectThrowsAsync(rokuDeploy.captureScreenshot({ host: options.host, password: 'password' }));
+            await expectThrowsAsync(rokuDeploy.captureScreenshot({ device: options.device, password: 'password' }));
         });
 
         it('handles the device returning a png', async () => {
@@ -3588,7 +3588,7 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: true });
+            let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password', out: true });
             expect(result.buffer).to.be.instanceOf(Buffer);
             expect(result.filePath).not.to.be.undefined;
             expect(path.extname(result.filePath)).to.equal('.png');
@@ -3616,7 +3616,7 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: true });
+            let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password', out: true });
             expect(result.buffer).to.be.instanceOf(Buffer);
             expect(result.filePath).not.to.be.undefined;
             expect(path.extname(result.filePath)).to.equal('.jpg');
@@ -3644,7 +3644,7 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/myScreenShots/screenshot` });
+            let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password', out: `${tempDir}/myScreenShots/screenshot` });
             expect(result.filePath).not.to.be.undefined;
             expect(util.standardizePath(`${tempDir}/myScreenShots`)).to.equal(path.dirname(result.filePath));
             expect(fsExtra.existsSync(result.filePath));
@@ -3671,7 +3671,7 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/my` });
+            let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password', out: `${tempDir}/my` });
             expect(result.filePath).not.to.be.undefined;
             expect(util.standardizePath(tempDir)).to.equal(path.dirname(result.filePath));
             expect(fsExtra.existsSync(path.join(tempDir, 'my')));
@@ -3698,7 +3698,7 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/my.jpg` });
+            let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password', out: `${tempDir}/my.jpg` });
             expect(result.filePath).not.to.be.undefined;
             expect(util.standardizePath(tempDir)).to.equal(path.dirname(result.filePath));
             // Without autoExtension, file is saved exactly as specified
@@ -3726,7 +3726,7 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password' });
+            let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password' });
             expect(result.buffer).to.be.instanceOf(Buffer);
             expect(result.buffer.toString()).to.equal('fake-image-data');
             expect(result.filePath).to.be.undefined;
@@ -3754,7 +3754,7 @@ describe('RokuDeploy', () => {
 
             mockDoPostRequest(body);
             // With autoExtension: false (default), user-provided filename is used exactly
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/myFile` });
+            let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password', out: `${tempDir}/myFile` });
             expect(result.filePath).not.to.be.undefined;
             expect(path.basename(result.filePath)).to.equal('myFile');
             expect(fsExtra.existsSync(result.filePath));
@@ -3781,7 +3781,7 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/myFile`, autoExtension: true });
+            let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password', out: `${tempDir}/myFile`, autoExtension: true });
             expect(result.filePath).not.to.be.undefined;
             expect(path.basename(result.filePath)).to.equal('myFile.jpg');
             expect(fsExtra.existsSync(result.filePath));
@@ -3809,7 +3809,7 @@ describe('RokuDeploy', () => {
 
             mockDoPostRequest(body);
             // User provides .png but device returns .jpg - should swap to .jpg
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/myFile.png`, autoExtension: true });
+            let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password', out: `${tempDir}/myFile.png`, autoExtension: true });
             expect(result.filePath).not.to.be.undefined;
             expect(path.basename(result.filePath)).to.equal('myFile.jpg');
             expect(fsExtra.existsSync(result.filePath));
@@ -3836,7 +3836,7 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/myFile.jpg`, autoExtension: true });
+            let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password', out: `${tempDir}/myFile.jpg`, autoExtension: true });
             expect(result.filePath).not.to.be.undefined;
             expect(path.basename(result.filePath)).to.equal('myFile.jpg');
             expect(fsExtra.existsSync(result.filePath));
@@ -3863,7 +3863,7 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: true });
+            let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password', out: true });
             expect(result.buffer).to.be.instanceOf(Buffer);
             expect(result.filePath).not.to.be.undefined;
             expect(fsExtra.existsSync(result.filePath)).to.be.true;
@@ -3890,7 +3890,7 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            let result = await rokuDeploy.captureScreenshot({ host: options.host, password: 'password', out: `${tempDir}/screenshot.png` });
+            let result = await rokuDeploy.captureScreenshot({ device: options.device, password: 'password', out: `${tempDir}/screenshot.png` });
             expect(result.buffer).to.be.instanceOf(Buffer);
             expect(result.buffer.toString()).to.equal('fake-image-data');
             expect(result.filePath).to.equal(path.join(tempDir, 'screenshot.png'));
@@ -3913,7 +3913,7 @@ describe('RokuDeploy', () => {
             };
 
             mockDoPostRequest(body);
-            await expectThrowsAsync(rokuDeploy.captureScreenshot({ host: options.host, password: 'password' }));
+            await expectThrowsAsync(rokuDeploy.captureScreenshot({ device: options.device, password: 'password' }));
         });
 
         describe('constructor defaults', () => {
@@ -3921,18 +3921,18 @@ describe('RokuDeploy', () => {
                 const rd = new RokuDeploy({ password: 'pass' });
                 await expectThrowsAsync(async () => {
                     await rd.captureScreenshot({} as any);
-                }, 'Missing required option: host');
+                }, 'Missing required option: device');
             });
 
             it('fails when password not provided in constructor or call', async () => {
-                const rd = new RokuDeploy({ host: 'localhost' });
+                const rd = new RokuDeploy({ device: { host: 'localhost' } });
                 await expectThrowsAsync(async () => {
                     await rd.captureScreenshot({} as any);
                 }, 'Missing required option: password');
             });
 
             it('uses constructor host when not provided in call', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '<img src="pkgs/dev.jpg?time=1234">' });
                 sinon.stub(rd as any, 'downloadToBuffer').resolves(Buffer.from('test'));
                 await rd.captureScreenshot({} as any);
@@ -3940,10 +3940,10 @@ describe('RokuDeploy', () => {
             });
 
             it('call host overrides constructor host', async () => {
-                const rd = new RokuDeploy({ host: 'constructor-host', password: 'pass' });
+                const rd = new RokuDeploy({ device: { host: 'constructor-host' }, password: 'pass' });
                 const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '<img src="pkgs/dev.jpg?time=1234">' });
                 sinon.stub(rd as any, 'downloadToBuffer').resolves(Buffer.from('test'));
-                await rd.captureScreenshot({ host: 'call-host' } as any);
+                await rd.captureScreenshot({ device: { host: 'call-host' } } as any);
                 expect(stub.getCall(0).args[0].url).to.include('call-host');
             });
         });
@@ -4752,58 +4752,58 @@ describe('RokuDeploy', () => {
         }
 
         it('throws error when sendKeyEvent is missing required options', async () => {
-            const requiredOptions: Partial<SendKeyEventOptions> = { host: '1.2.3.4', key: 'up' };
-            await testRequiredOptions('sendKeyEvent', requiredOptions, 'host');
+            const requiredOptions: Partial<SendKeyEventOptions> = { device: { host: '1.2.3.4' }, key: 'up' };
+            await testRequiredOptions('sendKeyEvent', requiredOptions, 'device');
             await testRequiredOptions('sendKeyEvent', requiredOptions, 'key');
         });
 
         it('throws error when sideload is missing required options', async () => {
-            const requiredOptions: Partial<SideloadOptions> = { host: '1.2.3.4', password: 'abcd' };
-            await testRequiredOptions('sideload', requiredOptions, 'host');
+            const requiredOptions: Partial<SideloadOptions> = { device: { host: '1.2.3.4' }, password: 'abcd' };
+            await testRequiredOptions('sideload', requiredOptions, 'device');
             await testRequiredOptions('sideload', requiredOptions, 'password');
         });
 
         it('throws error when convertToSquashfs is missing required options', async () => {
-            const requiredOptions: Partial<ConvertToSquashfsOptions> = { host: '1.2.3.4', password: 'abcd' };
-            await testRequiredOptions('convertToSquashfs', requiredOptions, 'host');
+            const requiredOptions: Partial<ConvertToSquashfsOptions> = { device: { host: '1.2.3.4' }, password: 'abcd' };
+            await testRequiredOptions('convertToSquashfs', requiredOptions, 'device');
             await testRequiredOptions('convertToSquashfs', requiredOptions, 'password');
         });
 
         it('throws error when rekeyDevice is missing required options', async () => {
-            const requiredOptions: Partial<RekeyDeviceOptions> = { host: '1.2.3.4', password: 'abcd', pkg: 'abcd', signingPassword: 'abcd' };
-            await testRequiredOptions('rekeyDevice', requiredOptions, 'host');
+            const requiredOptions: Partial<RekeyDeviceOptions> = { device: { host: '1.2.3.4' }, password: 'abcd', pkg: 'abcd', signingPassword: 'abcd' };
+            await testRequiredOptions('rekeyDevice', requiredOptions, 'device');
             await testRequiredOptions('rekeyDevice', requiredOptions, 'password');
             await testRequiredOptions('rekeyDevice', requiredOptions, 'pkg');
             await testRequiredOptions('rekeyDevice', requiredOptions, 'signingPassword');
         });
 
         it('throws error when createSignedPackage is missing required options', async () => {
-            const requiredOptions: Partial<CreateSignedPackageOptions> = { host: '1.2.3.4', password: 'abcd', signingPassword: 'abcd' };
-            await testRequiredOptions('createSignedPackage', requiredOptions, 'host');
+            const requiredOptions: Partial<CreateSignedPackageOptions> = { device: { host: '1.2.3.4' }, password: 'abcd', signingPassword: 'abcd' };
+            await testRequiredOptions('createSignedPackage', requiredOptions, 'device');
             await testRequiredOptions('createSignedPackage', requiredOptions, 'password');
             await testRequiredOptions('createSignedPackage', requiredOptions, 'signingPassword');
         });
 
         it('throws error when deleteDevChannel is missing required options', async () => {
-            const requiredOptions: Partial<DeleteDevChannelOptions> = { host: '1.2.3.4', password: 'abcd' };
-            await testRequiredOptions('deleteDevChannel', requiredOptions, 'host');
+            const requiredOptions: Partial<DeleteDevChannelOptions> = { device: { host: '1.2.3.4' }, password: 'abcd' };
+            await testRequiredOptions('deleteDevChannel', requiredOptions, 'device');
             await testRequiredOptions('deleteDevChannel', requiredOptions, 'password');
         });
 
         it('throws error when captureScreenshot is missing required options', async () => {
-            const requiredOptions: Partial<CaptureScreenshotOptions> = { host: '1.2.3.4', password: 'abcd' };
-            await testRequiredOptions('captureScreenshot', requiredOptions, 'host');
+            const requiredOptions: Partial<CaptureScreenshotOptions> = { device: { host: '1.2.3.4' }, password: 'abcd' };
+            await testRequiredOptions('captureScreenshot', requiredOptions, 'device');
             await testRequiredOptions('captureScreenshot', requiredOptions, 'password');
         });
 
         it('throws error when getDeviceInfo is missing required options', async () => {
-            const requiredOptions: Partial<GetDeviceInfoOptions> = { host: '1.2.3.4' };
-            await testRequiredOptions('getDeviceInfo', requiredOptions, 'host');
+            const requiredOptions: Partial<GetDeviceInfoOptions> = { device: { host: '1.2.3.4' } };
+            await testRequiredOptions('getDeviceInfo', requiredOptions, 'device');
         });
 
         it('throws error when getDevId is missing required options', async () => {
-            const requiredOptions: Partial<GetDevIdOptions> = { host: '1.2.3.4' };
-            await testRequiredOptions('getDevId', requiredOptions, 'host');
+            const requiredOptions: Partial<GetDevIdOptions> = { device: { host: '1.2.3.4' } };
+            await testRequiredOptions('getDevId', requiredOptions, 'device');
         });
     });
 
@@ -4820,7 +4820,7 @@ describe('RokuDeploy', () => {
             it('throws for non-integer port', async () => {
                 try {
                     await rokuDeploy.sideload({
-                        host: '1.2.3.4',
+                        device: { host: '1.2.3.4' },
                         password: 'test',
                         zip: 'test.zip',
                         packagePort: 80.5,
@@ -4835,7 +4835,7 @@ describe('RokuDeploy', () => {
             it('throws for port less than 1', async () => {
                 try {
                     await rokuDeploy.sideload({
-                        host: '1.2.3.4',
+                        device: { host: '1.2.3.4' },
                         password: 'test',
                         zip: 'test.zip',
                         packagePort: 0,
@@ -4850,7 +4850,7 @@ describe('RokuDeploy', () => {
             it('throws for port greater than 65535', async () => {
                 try {
                     await rokuDeploy.sideload({
-                        host: '1.2.3.4',
+                        device: { host: '1.2.3.4' },
                         password: 'test',
                         zip: 'test.zip',
                         packagePort: 65536,
@@ -4865,7 +4865,7 @@ describe('RokuDeploy', () => {
             it('throws for string port', async () => {
                 try {
                     await rokuDeploy.sideload({
-                        host: '1.2.3.4',
+                        device: { host: '1.2.3.4' },
                         password: 'test',
                         zip: 'test.zip',
                         packagePort: '80' as any,
@@ -4881,7 +4881,7 @@ describe('RokuDeploy', () => {
                 mockDoPostRequest();
                 // Should not throw - valid port
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'test',
                     zip: zipFile,
                     packagePort: 8080,
@@ -4894,7 +4894,7 @@ describe('RokuDeploy', () => {
             it('throws for non-integer timeout', async () => {
                 try {
                     await rokuDeploy.sideload({
-                        host: '1.2.3.4',
+                        device: { host: '1.2.3.4' },
                         password: 'test',
                         zip: 'test.zip',
                         timeout: 1000.5,
@@ -4909,7 +4909,7 @@ describe('RokuDeploy', () => {
             it('throws for negative timeout', async () => {
                 try {
                     await rokuDeploy.sideload({
-                        host: '1.2.3.4',
+                        device: { host: '1.2.3.4' },
                         password: 'test',
                         zip: 'test.zip',
                         timeout: -1,
@@ -4924,7 +4924,7 @@ describe('RokuDeploy', () => {
             it('throws for zero timeout', async () => {
                 try {
                     await rokuDeploy.sideload({
-                        host: '1.2.3.4',
+                        device: { host: '1.2.3.4' },
                         password: 'test',
                         zip: 'test.zip',
                         timeout: 0,
@@ -4941,7 +4941,7 @@ describe('RokuDeploy', () => {
             it('throws for invalid appType', async () => {
                 try {
                     await rokuDeploy.sideload({
-                        host: '1.2.3.4',
+                        device: { host: '1.2.3.4' },
                         password: 'test',
                         zip: 'test.zip',
                         appType: 'invalid' as any,
@@ -4957,14 +4957,14 @@ describe('RokuDeploy', () => {
                 mockDoPostRequest();
                 // Should not throw
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'test',
                     zip: zipFile,
                     appType: 'channel',
                     close: false
                 });
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'test',
                     zip: zipFile,
                     appType: 'dcl',
@@ -4976,7 +4976,7 @@ describe('RokuDeploy', () => {
                 mockDoPostRequest();
                 // Should not throw
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'test',
                     zip: zipFile,
                     close: false
@@ -4987,7 +4987,7 @@ describe('RokuDeploy', () => {
                 mockDoPostRequest();
                 // Should not throw - null means "don't include"
                 await rokuDeploy.sideload({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'test',
                     zip: zipFile,
                     appType: null,
@@ -5000,7 +5000,7 @@ describe('RokuDeploy', () => {
             it('throws for invalid ecpPort in getDeviceInfo', async () => {
                 try {
                     await rokuDeploy.getDeviceInfo({
-                        host: '1.2.3.4',
+                        device: { host: '1.2.3.4' },
                         ecpPort: 'invalid' as any
                     });
                     assert.fail('Should have thrown');
@@ -5182,7 +5182,7 @@ describe('RokuDeploy', () => {
         it('attempts to delete the dev channel and all component libraries on the device', async () => {
             const stub = mockDoPostRequest();
 
-            let result = await rokuDeploy.deleteAllSideloadedPlugins({ ...options, host: 'localhost', password: 'password' });
+            let result = await rokuDeploy.deleteAllSideloadedPlugins({ ...options, device: { host: 'localhost' }, password: 'password' });
             expect(result).not.to.be.undefined;
             expect(stub.getCall(0).args[0].formData).to.include({
                 mysubmit: 'DeleteAll'
@@ -5194,7 +5194,7 @@ describe('RokuDeploy', () => {
         it('sends the dcl_enabled qs flag', async () => {
             const stub = mockDoGetRequest();
             sinon.stub(rokuDeploy as any, 'getPackagesFromResponseBody').returns([]);
-            const result = await rokuDeploy.listSideloadedPlugins({ host: 'localhost', password: 'test' } as any);
+            const result = await rokuDeploy.listSideloadedPlugins({ device: { host: 'localhost' }, password: 'test' } as any);
             expect(stub.getCall(0).args[0].qs.dcl_enabled).to.eql('1');
             expect(result).to.eql([]);
         });
@@ -5207,7 +5207,7 @@ describe('RokuDeploy', () => {
             } as any);
             const stub = mockDoGetRequest();
             sinon.stub(rokuDeploy as any, 'getPackagesFromResponseBody').returns([]);
-            const result = await rokuDeploy.listSideloadedPlugins({ host: 'localhost', password: 'test' } as any);
+            const result = await rokuDeploy.listSideloadedPlugins({ device: { host: 'localhost' }, password: 'test' } as any);
             expect(stub.getCall(0).args[0].qs).to.eql({
                 existing: 'value',
                 dcl_enabled: '1'
@@ -5219,7 +5219,7 @@ describe('RokuDeploy', () => {
             const stub = mockDoGetRequest(`
                 var params = JSON.parse('{"messages":null,"metadata":{"dev_id":"12345","dev_key":true,"voice_sdk":false},"packages":[{"appType":"channel","archiveFileName":"roku-deploy.zip","fileType":"zip","id":"0","location":"nvram","md5":"a8d2f9974e2736174c1033b8a7183288","pkgPath":"","size":"2267547"}]}');
             `);
-            const result = await rokuDeploy.listSideloadedPlugins({ host: 'localhost', password: 'test' } as any);
+            const result = await rokuDeploy.listSideloadedPlugins({ device: { host: 'localhost' }, password: 'test' } as any);
             expect(stub.getCall(0).args[0].qs.dcl_enabled).to.eql('1');
             expect(result).to.eql([{
                 appType: 'channel',
@@ -5237,7 +5237,7 @@ describe('RokuDeploy', () => {
             mockDoGetRequest(`
                 var params = JSON.parse('{"messages":null,"metadata":{"dev_id":"12345","dev_key":true,"voice_sdk":false},"packages": 123}');
             `);
-            const result = await rokuDeploy.listSideloadedPlugins({ host: 'localhost', password: 'test' } as any);
+            const result = await rokuDeploy.listSideloadedPlugins({ device: { host: 'localhost' }, password: 'test' } as any);
             expect(result).to.eql([]);
         });
 
@@ -5245,7 +5245,7 @@ describe('RokuDeploy', () => {
             mockDoGetRequest(`
                 var params = JSON.parse('123');
             `);
-            const result = await rokuDeploy.listSideloadedPlugins({ host: 'localhost', password: 'test' } as any);
+            const result = await rokuDeploy.listSideloadedPlugins({ device: { host: 'localhost' }, password: 'test' } as any);
             expect(result).to.eql([]);
         });
     });
@@ -5255,7 +5255,7 @@ describe('RokuDeploy', () => {
             const stub = mockDoPostRequest();
 
             sinon.stub(rokuDeploy as any, 'generateBaseRequestOptions').returns({} as any);
-            await rokuDeploy.deleteComponentLibrary({ host: 'localhost', password: 'test', fileName: 'test.zip' } as any);
+            await rokuDeploy.deleteComponentLibrary({ device: { host: 'localhost' }, password: 'test', fileName: 'test.zip' } as any);
 
             expect(stub.getCall(0).args[0].qs.dcl_enabled).to.eql('1');
         });
@@ -5268,7 +5268,7 @@ describe('RokuDeploy', () => {
             } as any);
             const stub = mockDoPostRequest();
 
-            await rokuDeploy.deleteComponentLibrary({ host: 'localhost', password: 'test', fileName: 'test.zip' } as any);
+            await rokuDeploy.deleteComponentLibrary({ device: { host: 'localhost' }, password: 'test', fileName: 'test.zip' } as any);
 
             expect(stub.getCall(0).args[0].qs).to.eql({
                 existing: 'value',
@@ -5283,7 +5283,7 @@ describe('RokuDeploy', () => {
             const stub = mockDoPostRequest();
 
             await rokuDeploy.deleteComponentLibrary({
-                host: '0.0.0.0',
+                device: { host: '0.0.0.0' },
                 password: 'aaaa',
                 fileName: 'fakeFile.zip'
             });
@@ -5415,16 +5415,16 @@ describe('RokuDeploy', () => {
 
     describe('defaults', () => {
         describe('constructor defaults', () => {
-            describe('host option', () => {
+            describe('device option', () => {
                 it('fails when not provided in constructor or call', async () => {
                     const rd = new RokuDeploy();
                     await expectThrowsAsync(async () => {
                         await rd['sendKeyEvent']({ key: 'home', action: 'keypress' } as any);
-                    }, 'Missing required option: host');
+                    }, 'Missing required option: device');
                 });
 
                 it('uses constructor value when not provided in call', async () => {
-                    const rd = new RokuDeploy({ host: 'constructor-host' });
+                    const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                     const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
                     await rd['sendKeyEvent']({ key: 'home', action: 'keypress' } as any);
                     expect(stub.getCall(0).args[0].url).to.include('constructor-host');
@@ -5433,35 +5433,35 @@ describe('RokuDeploy', () => {
                 it('uses call value when not provided in constructor', async () => {
                     const rd = new RokuDeploy();
                     const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
-                    await rd['sendKeyEvent']({ host: 'call-host', key: 'home', action: 'keypress' });
+                    await rd['sendKeyEvent']({ device: { host: 'call-host' }, key: 'home', action: 'keypress' });
                     expect(stub.getCall(0).args[0].url).to.include('call-host');
                 });
 
                 it('call value overrides constructor value', async () => {
-                    const rd = new RokuDeploy({ host: 'constructor-host' });
+                    const rd = new RokuDeploy({ device: { host: 'constructor-host' } });
                     const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
-                    await rd['sendKeyEvent']({ host: 'call-host', key: 'home', action: 'keypress' });
+                    await rd['sendKeyEvent']({ device: { host: 'call-host' }, key: 'home', action: 'keypress' });
                     expect(stub.getCall(0).args[0].url).to.include('call-host');
                 });
             });
 
             describe('password option', () => {
                 it('fails when not provided in constructor or call', async () => {
-                    const rd = new RokuDeploy();
+                    const rd = new RokuDeploy({ device: { host: 'localhost' } });
                     await expectThrowsAsync(async () => {
-                        await rd.deleteDevChannel({ host: 'localhost' } as any);
+                        await rd.deleteDevChannel();
                     }, 'Missing required option: password');
                 });
 
                 it('uses constructor value when not provided in call', async () => {
-                    const rd = new RokuDeploy({ host: 'localhost', password: 'constructor-pass' });
+                    const rd = new RokuDeploy({ device: { host: 'localhost' }, password: 'constructor-pass' });
                     const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '', response: { statusCode: 200 } });
                     await rd.deleteDevChannel();
                     expect(stub.getCall(0).args[0].auth.pass).to.equal('constructor-pass');
                 });
 
                 it('call value overrides constructor value', async () => {
-                    const rd = new RokuDeploy({ host: 'localhost', password: 'constructor-pass' });
+                    const rd = new RokuDeploy({ device: { host: 'localhost' }, password: 'constructor-pass' });
                     const stub = sinon.stub(rd as any, 'doPostRequest').resolves({ body: '', response: { statusCode: 200 } });
                     await rd.deleteDevChannel({ password: 'call-pass' } as any);
                     expect(stub.getCall(0).args[0].auth.pass).to.equal('call-pass');
@@ -5472,21 +5472,21 @@ describe('RokuDeploy', () => {
                 it('uses static default when not provided anywhere', async () => {
                     const rd = new RokuDeploy();
                     const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
-                    await rd['sendKeyEvent']({ host: 'localhost', key: 'home', action: 'keypress' });
+                    await rd['sendKeyEvent']({ device: { host: 'localhost' }, key: 'home', action: 'keypress' });
                     expect(stub.getCall(0).args[0].url).to.include(':8060/');
                 });
 
                 it('uses constructor value when not provided in call', async () => {
                     const rd = new RokuDeploy({ ecpPort: 9000 });
                     const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
-                    await rd['sendKeyEvent']({ host: 'localhost', key: 'home', action: 'keypress' });
+                    await rd['sendKeyEvent']({ device: { host: 'localhost' }, key: 'home', action: 'keypress' });
                     expect(stub.getCall(0).args[0].url).to.include(':9000/');
                 });
 
                 it('call value overrides constructor value', async () => {
                     const rd = new RokuDeploy({ ecpPort: 9000 });
                     const stub = sinon.stub(rd as any, 'doPostRequest').resolves({});
-                    await rd['sendKeyEvent']({ host: 'localhost', key: 'home', action: 'keypress', ecpPort: 9999 });
+                    await rd['sendKeyEvent']({ device: { host: 'localhost' }, key: 'home', action: 'keypress', ecpPort: 9999 });
                     expect(stub.getCall(0).args[0].url).to.include(':9999/');
                 });
             });
@@ -5494,19 +5494,19 @@ describe('RokuDeploy', () => {
             describe('packagePort option', () => {
                 it('uses static default when not provided anywhere', () => {
                     const rd = new RokuDeploy();
-                    const result = rd['generateBaseRequestOptions']('test', { host: 'localhost', password: 'test' });
+                    const result = rd['generateBaseRequestOptions']('test', 'localhost', { device: { host: 'localhost' }, password: 'test' });
                     expect(result.url).to.include(':80/');
                 });
 
                 it('uses constructor value when not provided in call', () => {
                     const rd = new RokuDeploy({ packagePort: 8080 });
-                    const result = rd['generateBaseRequestOptions']('test', { host: 'localhost', password: 'test' });
+                    const result = rd['generateBaseRequestOptions']('test', 'localhost', { device: { host: 'localhost' }, password: 'test' });
                     expect(result.url).to.include(':8080/');
                 });
 
                 it('call value overrides constructor value', () => {
                     const rd = new RokuDeploy({ packagePort: 8080 });
-                    const result = rd['generateBaseRequestOptions']('test', { host: 'localhost', password: 'test', packagePort: 9090 });
+                    const result = rd['generateBaseRequestOptions']('test', 'localhost', { device: { host: 'localhost' }, password: 'test', packagePort: 9090 });
                     expect(result.url).to.include(':9090/');
                 });
             });
@@ -5614,32 +5614,32 @@ describe('RokuDeploy', () => {
 
         describe('generateBaseRequestOptions', () => {
             it('uses default timeout', () => {
-                const result = rokuDeploy['generateBaseRequestOptions']('test', { host: 'localhost', password: 'test' });
+                const result = rokuDeploy['generateBaseRequestOptions']('test', 'localhost', { device: { host: 'localhost' }, password: 'test' });
                 expect(result.timeout).to.equal(RokuDeploy['defaults'].timeout);
             });
 
             it('uses default packagePort', () => {
-                const result = rokuDeploy['generateBaseRequestOptions']('test', { host: 'localhost', password: 'test' });
+                const result = rokuDeploy['generateBaseRequestOptions']('test', 'localhost', { device: { host: 'localhost' }, password: 'test' });
                 expect(result.url).to.equal(`http://localhost:${RokuDeploy['defaults'].packagePort}/test`);
             });
 
             it('uses default username of rokudev', () => {
-                const result = rokuDeploy['generateBaseRequestOptions']('test', { host: 'localhost', password: 'test' });
+                const result = rokuDeploy['generateBaseRequestOptions']('test', 'localhost', { device: { host: 'localhost' }, password: 'test' });
                 expect(result.auth.user).to.equal('rokudev');
             });
 
             it('allows overriding timeout', () => {
-                const result = rokuDeploy['generateBaseRequestOptions']('test', { host: 'localhost', password: 'test', timeout: 5000 });
+                const result = rokuDeploy['generateBaseRequestOptions']('test', 'localhost', { device: { host: 'localhost' }, password: 'test', timeout: 5000 });
                 expect(result.timeout).to.equal(5000);
             });
 
             it('allows overriding packagePort', () => {
-                const result = rokuDeploy['generateBaseRequestOptions']('test', { host: 'localhost', password: 'test', packagePort: 8080 });
+                const result = rokuDeploy['generateBaseRequestOptions']('test', 'localhost', { device: { host: 'localhost' }, password: 'test', packagePort: 8080 });
                 expect(result.url).to.equal('http://localhost:8080/test');
             });
 
             it('allows overriding username', () => {
-                const result = rokuDeploy['generateBaseRequestOptions']('test', { host: 'localhost', password: 'test', username: 'admin' });
+                const result = rokuDeploy['generateBaseRequestOptions']('test', 'localhost', { device: { host: 'localhost' }, password: 'test', username: 'admin' });
                 expect(result.auth.user).to.equal('admin');
             });
         });
@@ -5647,19 +5647,19 @@ describe('RokuDeploy', () => {
         describe('sendKeyEvent', () => {
             it('uses default ecpPort', async () => {
                 const stub = sinon.stub(rokuDeploy as any, 'doPostRequest').resolves({});
-                await rokuDeploy['sendKeyEvent']({ host: 'localhost', key: 'home', action: 'keypress' });
+                await rokuDeploy['sendKeyEvent']({ device: { host: 'localhost' }, key: 'home', action: 'keypress' });
                 expect(stub.getCall(0).args[0].url).to.include(`:${RokuDeploy['defaults'].ecpPort}/`);
             });
 
             it('uses default timeout', async () => {
                 const stub = sinon.stub(rokuDeploy as any, 'doPostRequest').resolves({});
-                await rokuDeploy['sendKeyEvent']({ host: 'localhost', key: 'home', action: 'keypress' });
+                await rokuDeploy['sendKeyEvent']({ device: { host: 'localhost' }, key: 'home', action: 'keypress' });
                 expect(stub.getCall(0).args[0].timeout).to.equal(RokuDeploy['defaults'].timeout);
             });
 
             it('allows overriding ecpPort', async () => {
                 const stub = sinon.stub(rokuDeploy as any, 'doPostRequest').resolves({});
-                await rokuDeploy['sendKeyEvent']({ host: 'localhost', key: 'home', action: 'keypress', ecpPort: 9000 });
+                await rokuDeploy['sendKeyEvent']({ device: { host: 'localhost' }, key: 'home', action: 'keypress', ecpPort: 9000 });
                 expect(stub.getCall(0).args[0].url).to.include(':9000/');
             });
         });
@@ -5669,7 +5669,7 @@ describe('RokuDeploy', () => {
                 const stub = sinon.stub(rokuDeploy as any, 'doGetRequest').resolves({ body: '<device-info></device-info>' });
                 sinon.stub(util, 'dnsLookup').resolves('localhost');
                 try {
-                    await rokuDeploy.getDeviceInfo({ host: 'localhost' });
+                    await rokuDeploy.getDeviceInfo({ device: { host: 'localhost' } });
                 } catch (e) {
                     // ignore parse errors
                 }
@@ -5680,7 +5680,7 @@ describe('RokuDeploy', () => {
                 const stub = sinon.stub(rokuDeploy as any, 'doGetRequest').resolves({ body: '<device-info></device-info>' });
                 sinon.stub(util, 'dnsLookup').resolves('localhost');
                 try {
-                    await rokuDeploy.getDeviceInfo({ host: 'localhost' });
+                    await rokuDeploy.getDeviceInfo({ device: { host: 'localhost' } });
                 } catch (e) {
                     // ignore parse errors
                 }
@@ -5727,7 +5727,7 @@ describe('RokuDeploy', () => {
                 sinon.stub(fsExtra, 'createReadStream').returns({ on: (event, cb) => cb() } as any);
                 mockDoPostRequest('success');
 
-                await rokuDeploy.sideload({ host: 'localhost', password: 'test', zip: 'test.zip' });
+                await rokuDeploy.sideload({ device: { host: 'localhost' }, password: 'test', zip: 'test.zip' });
                 expect(deleteStub.called).to.be.true;
             });
 
@@ -5738,7 +5738,7 @@ describe('RokuDeploy', () => {
                 sinon.stub(fsExtra, 'createReadStream').returns({ on: (event, cb) => cb() } as any);
                 mockDoPostRequest('success');
 
-                await rokuDeploy.sideload({ host: 'localhost', password: 'test', zip: 'test.zip', deleteDevChannel: false });
+                await rokuDeploy.sideload({ device: { host: 'localhost' }, password: 'test', zip: 'test.zip', deleteDevChannel: false });
                 expect(deleteStub.called).to.be.false;
             });
 
@@ -5750,7 +5750,7 @@ describe('RokuDeploy', () => {
                 mockDoPostRequest('success');
 
                 //a `dcl` install lives in its own slot; deleting the dev channel would needlessly wipe an installed channel
-                await rokuDeploy.sideload({ host: 'localhost', password: 'test', zip: 'test.zip', appType: 'dcl' });
+                await rokuDeploy.sideload({ device: { host: 'localhost' }, password: 'test', zip: 'test.zip', appType: 'dcl' });
                 expect(deleteStub.called).to.be.false;
             });
         });
@@ -5778,7 +5778,7 @@ describe('RokuDeploy', () => {
                 .onFirstCall().resolves(fakeResponse(401, { 'www-authenticate': CHALLENGE_HEADER }))
                 .onSecondCall().resolves(fakeResponse(200));
 
-            const result = await rokuDeploy.validateDeveloperPassword({ host: '1.2.3.4', password: 'aaaa' });
+            const result = await rokuDeploy.validateDeveloperPassword({ device: { host: '1.2.3.4' }, password: 'aaaa' });
 
             expect(result).to.be.true;
             expect(fetchStub.callCount).to.equal(2);
@@ -5795,7 +5795,7 @@ describe('RokuDeploy', () => {
                 .onFirstCall().resolves(fakeResponse(401, { 'www-authenticate': CHALLENGE_HEADER }))
                 .onSecondCall().resolves(fakeResponse(401, { 'www-authenticate': CHALLENGE_HEADER }));
 
-            const result = await rokuDeploy.validateDeveloperPassword({ host: '1.2.3.4', password: 'wrong' });
+            const result = await rokuDeploy.validateDeveloperPassword({ device: { host: '1.2.3.4' }, password: 'wrong' });
 
             expect(result).to.be.false;
         });
@@ -5805,7 +5805,7 @@ describe('RokuDeploy', () => {
 
             let thrown: unknown;
             try {
-                await rokuDeploy.validateDeveloperPassword({ host: '1.2.3.4', password: 'aaaa' });
+                await rokuDeploy.validateDeveloperPassword({ device: { host: '1.2.3.4' }, password: 'aaaa' });
             } catch (e) {
                 thrown = e;
             }
@@ -5818,7 +5818,7 @@ describe('RokuDeploy', () => {
 
             let thrown: unknown;
             try {
-                await rokuDeploy.validateDeveloperPassword({ host: '1.2.3.4', password: 'aaaa' });
+                await rokuDeploy.validateDeveloperPassword({ device: { host: '1.2.3.4' }, password: 'aaaa' });
             } catch (e) {
                 thrown = e;
             }
@@ -5829,7 +5829,7 @@ describe('RokuDeploy', () => {
         it('returns false when a 401 has no WWW-Authenticate header', async () => {
             sinon.stub(httpClient, 'fetch').resolves(fakeResponse(401));
 
-            const result = await rokuDeploy.validateDeveloperPassword({ host: '1.2.3.4', password: 'aaaa' });
+            const result = await rokuDeploy.validateDeveloperPassword({ device: { host: '1.2.3.4' }, password: 'aaaa' });
 
             expect(result).to.be.false;
         });
@@ -5839,7 +5839,7 @@ describe('RokuDeploy', () => {
                 .onFirstCall().resolves(fakeResponse(401, { 'www-authenticate': CHALLENGE_HEADER }))
                 .onSecondCall().resolves(fakeResponse(200));
 
-            await rokuDeploy.validateDeveloperPassword({ host: 'device.local', password: 'aaaa' });
+            await rokuDeploy.validateDeveloperPassword({ device: { host: 'device.local' }, password: 'aaaa' });
 
             expect(fetchStub.firstCall.args[0]).to.equal('http://device.local:80/plugin_install');
             const authHeader = (fetchStub.secondCall.args[1] as any).headers.Authorization as string;
@@ -5852,7 +5852,7 @@ describe('RokuDeploy', () => {
                 .onSecondCall().resolves(fakeResponse(200));
 
             await rokuDeploy.validateDeveloperPassword({
-                host: 'device.local',
+                device: { host: 'device.local' },
                 password: 'aaaa',
                 username: 'somebody',
                 port: 8888
@@ -5877,7 +5877,7 @@ describe('RokuDeploy', () => {
             let thrown: unknown;
             try {
                 await rokuDeploy.validateDeveloperPassword({
-                    host: '1.2.3.4',
+                    device: { host: '1.2.3.4' },
                     password: 'aaaa',
                     timeout: 20
                 });
@@ -5892,7 +5892,7 @@ describe('RokuDeploy', () => {
 
             let thrown: unknown;
             try {
-                await rokuDeploy.validateDeveloperPassword({ host: '1.2.3.4', password: 'aaaa' });
+                await rokuDeploy.validateDeveloperPassword({ device: { host: '1.2.3.4' }, password: 'aaaa' });
             } catch (e) {
                 thrown = e;
             }

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -1699,8 +1699,7 @@ export interface RokuPlugin {
 }
 export type RokuPackage = RokuPlugin;
 
-export interface ListSideloadedPluginsOptions extends BaseRequestOptions {
-}
+export type ListSideloadedPluginsOptions = BaseRequestOptions;
 
 enum RokuMessageType {
     success = 'success',

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -23,7 +23,9 @@ import {
 import * as xml2js from 'xml2js';
 import { parse as parseJsonc, printParseErrorCode, type ParseError } from 'jsonc-parser';
 import { util } from './util';
-import type { FileEntry, RokuDeployConstructorOptions, RokuDeployOptions } from './RokuDeployOptions';
+import type { DeviceRegistryEntry, FileEntry, RokuDeployConstructorOptions, RokuDeployOptions } from './RokuDeployOptions';
+import { isRceDeviceConfig } from './DeviceConfig';
+import type { DeviceConfig, DeviceOption } from './DeviceConfig';
 import { logger } from '@rokucommunity/logger';
 import type { DeviceInfo, DeviceInfoRaw } from './DeviceInfo';
 import * as semver from 'semver';
@@ -273,7 +275,7 @@ export class RokuDeploy {
         return [...result.values()];
     }
 
-    private generateBaseRequestOptions<T>(requestPath: string, options: BaseRequestOptions, formData = {} as T): RequestOptions {
+    private generateBaseRequestOptions<T>(requestPath: string, host: string, options: BaseRequestOptions, formData = {} as T): RequestOptions {
         // Merge constructor options with call options
         const mergedOptions = { ...this.options, ...options };
         // Set defaults for request options
@@ -281,7 +283,7 @@ export class RokuDeploy {
         const timeout = mergedOptions.timeout ?? RokuDeploy.defaults.timeout;
         const username = mergedOptions.username ?? 'rokudev';
 
-        let url = `http://${mergedOptions.host}:${packagePort}/${requestPath}`;
+        let url = `http://${host}:${packagePort}/${requestPath}`;
         let baseRequestOptions = {
             url: url,
             timeout: timeout,
@@ -323,7 +325,7 @@ export class RokuDeploy {
 
     public async sendText(options: SendTextOptions) {
         options = { ...this.options, ...options } as SendTextOptions;
-        this.checkRequiredOptions(options, ['host', 'text']);
+        this.checkRequiredOptions(options, ['device', 'text']);
         const chars = options.text.split('');
         for (const char of chars) {
             await this.sendKeyEvent({
@@ -341,15 +343,19 @@ export class RokuDeploy {
     private async sendKeyEvent(options: SendKeyEventOptions) {
         options = { ...this.options, ...options } as SendKeyEventOptions;
         this.logger.info('Sending key event:', options.key);
-        this.checkRequiredOptions(options, ['host', 'key']);
+        this.checkRequiredOptions(options, ['device', 'key']);
         this.validatePort(options.ecpPort, 'ecpPort');
         this.validateTimeout(options.timeout);
+
+        const deviceConfig = this.resolveDevice(options.device);
+        const host = this.getHost(deviceConfig);
+
         // Set defaults
         const ecpPort = options.ecpPort ?? RokuDeploy.defaults.ecpPort;
         const timeout = options.timeout ?? RokuDeploy.defaults.timeout;
         // press the home button to return to the main screen
         return this.doPostRequest({
-            url: `http://${options.host}:${ecpPort}/${options.action}/${options.key}`,
+            url: `http://${host}:${ecpPort}/${options.action}/${options.key}`,
             timeout: timeout
         }, false);
     }
@@ -372,10 +378,13 @@ export class RokuDeploy {
     public async sideload(options: SideloadOptions): Promise<{ message: string; results: any }> {
         options = { ...this.options, ...options } as SideloadOptions;
         this.logger.info('Beginning to sideload package');
-        this.checkRequiredOptions(options, ['host', 'password']);
+        this.checkRequiredOptions(options, ['device', 'password']);
         this.validatePort(options.packagePort, 'packagePort');
         this.validateTimeout(options.timeout);
         this.validateEnum(options.appType, 'appType', ['channel', 'dcl'] as const);
+
+        const deviceConfig = this.resolveDevice(options.device);
+        const host = this.getHost(deviceConfig);
 
         const cwd = options.cwd ?? process.cwd();
         // Set defaults
@@ -425,7 +434,7 @@ export class RokuDeploy {
             });
 
             const route = options.packageUploadOverrides?.route ?? 'plugin_install';
-            let requestOptions = this.generateBaseRequestOptions(route, options, {
+            let requestOptions = this.generateBaseRequestOptions(route, host, options, {
                 mysubmit: 'Replace',
                 archive: readStream,
                 ...(options.appType ? { 'app_type': options.appType } : {})
@@ -595,10 +604,14 @@ export class RokuDeploy {
      */
     public async convertToSquashfs(options: ConvertToSquashfsOptions) {
         options = { ...this.options, ...options } as ConvertToSquashfsOptions;
-        this.checkRequiredOptions(options, ['host', 'password']);
+        this.checkRequiredOptions(options, ['device', 'password']);
         this.validatePort(options.packagePort, 'packagePort');
         this.validateTimeout(options.timeout);
-        let requestOptions = this.generateBaseRequestOptions('plugin_install', options, {
+
+        const deviceConfig = this.resolveDevice(options.device);
+        const host = this.getHost(deviceConfig);
+
+        let requestOptions = this.generateBaseRequestOptions('plugin_install', host, options, {
             archive: '',
             mysubmit: 'Convert to squashfs'
         });
@@ -638,16 +651,20 @@ export class RokuDeploy {
      */
     public async rekeyDevice(options: RekeyDeviceOptions) {
         options = { ...this.options, ...options } as RekeyDeviceOptions;
-        this.checkRequiredOptions(options, ['host', 'password', 'pkg', 'signingPassword']);
+        this.checkRequiredOptions(options, ['device', 'password', 'pkg', 'signingPassword']);
         this.validatePort(options.packagePort, 'packagePort');
         this.validateTimeout(options.timeout);
+
+        const deviceConfig = this.resolveDevice(options.device);
+        const host = this.getHost(deviceConfig);
+
         const cwd = path.resolve(process.cwd(), options.cwd ?? '.');
 
         let pkgPath = options.pkg;
         if (!path.isAbsolute(options.pkg)) {
             pkgPath = path.resolve(cwd, options.pkg);
         }
-        let requestOptions = this.generateBaseRequestOptions('plugin_inspect', options as any, {
+        let requestOptions = this.generateBaseRequestOptions('plugin_inspect', host, options as any, {
             mysubmit: 'Rekey',
             passwd: options.signingPassword,
             archive: null as ReadStream
@@ -700,9 +717,13 @@ export class RokuDeploy {
     public async createSignedPackage(options: CreateSignedPackageOptions): Promise<CreateSignedPackageResult> {
         options = { ...this.options, ...options } as CreateSignedPackageOptions;
         this.logger.info('Creating signed package');
-        this.checkRequiredOptions(options, ['host', 'password', 'signingPassword']);
+        this.checkRequiredOptions(options, ['device', 'password', 'signingPassword']);
         this.validatePort(options.packagePort, 'packagePort');
         this.validateTimeout(options.timeout);
+
+        const deviceConfig = this.resolveDevice(options.device);
+        const host = this.getHost(deviceConfig);
+
         const cwd = options.cwd ?? process.cwd();
 
         // Resolve output pkg path - use 'out' if provided, otherwise derive from default
@@ -747,7 +768,7 @@ export class RokuDeploy {
             }
         }
 
-        let requestOptions = this.generateBaseRequestOptions('plugin_package', options, {
+        let requestOptions = this.generateBaseRequestOptions('plugin_package', host, options, {
             mysubmit: 'Package',
             pkg_time: (new Date()).getTime(), //eslint-disable-line camelcase
             passwd: options.signingPassword,
@@ -772,7 +793,7 @@ export class RokuDeploy {
         }
         if (pkgSearchMatches) {
             const url = pkgSearchMatches[1];
-            let requestOptions2 = this.generateBaseRequestOptions(url, options);
+            let requestOptions2 = this.generateBaseRequestOptions(url, host, options);
             await this.downloadFile(requestOptions2, out);
             this.logger.info('Signed package created at:', out);
             return { pkgPath: out };
@@ -1018,11 +1039,14 @@ export class RokuDeploy {
     public async deleteDevChannel(options?: DeleteDevChannelOptions) {
         options = { ...this.options, ...options } as DeleteDevChannelOptions;
         this.logger.info('Deleting dev channel...');
-        this.checkRequiredOptions(options, ['host', 'password']);
+        this.checkRequiredOptions(options, ['device', 'password']);
         this.validatePort(options.packagePort, 'packagePort');
         this.validateTimeout(options.timeout);
 
-        let deleteOptions = this.generateBaseRequestOptions('plugin_install', options);
+        const deviceConfig = this.resolveDevice(options.device);
+        const host = this.getHost(deviceConfig);
+
+        let deleteOptions = this.generateBaseRequestOptions('plugin_install', host, options);
         deleteOptions.formData = {
             mysubmit: 'Delete',
             archive: ''
@@ -1036,9 +1060,12 @@ export class RokuDeploy {
      */
     public async deleteAllSideloadedPlugins(options?: DeleteDevChannelOptions) {
         options = { ...this.options, ...options } as DeleteDevChannelOptions;
-        this.checkRequiredOptions(options, ['host', 'password']);
+        this.checkRequiredOptions(options, ['device', 'password']);
 
-        let deleteOptions = this.generateBaseRequestOptions('plugin_install', options);
+        const deviceConfig = this.resolveDevice(options.device);
+        const host = this.getHost(deviceConfig);
+
+        let deleteOptions = this.generateBaseRequestOptions('plugin_install', host, options);
         deleteOptions.formData = {
             mysubmit: 'DeleteAll',
             archive: ''
@@ -1051,9 +1078,12 @@ export class RokuDeploy {
      */
     public async deleteComponentLibrary(options?: DeleteComponentLibraryOptions) {
         options = { ...this.options, ...options } as DeleteComponentLibraryOptions;
-        this.checkRequiredOptions(options, ['host', 'password', 'fileName']);
+        this.checkRequiredOptions(options, ['device', 'password', 'fileName']);
 
-        let deleteOptions = this.generateBaseRequestOptions('plugin_install', options);
+        const deviceConfig = this.resolveDevice(options.device);
+        const host = this.getHost(deviceConfig);
+
+        let deleteOptions = this.generateBaseRequestOptions('plugin_install', host, options);
         deleteOptions.formData = {
             mysubmit: 'Delete',
             'app_type': 'dcl',
@@ -1087,8 +1117,12 @@ export class RokuDeploy {
      */
     public async listSideloadedPlugins(options: ListSideloadedPluginsOptions): Promise<RokuPlugin[]> {
         options = { ...this.options, ...options } as ListSideloadedPluginsOptions;
-        this.checkRequiredOptions(options, ['host', 'password']);
-        let deleteOptions = this.generateBaseRequestOptions('plugin_install', options);
+        this.checkRequiredOptions(options, ['device', 'password']);
+
+        const deviceConfig = this.resolveDevice(options.device);
+        const host = this.getHost(deviceConfig);
+
+        let deleteOptions = this.generateBaseRequestOptions('plugin_install', host, options);
         deleteOptions.qs ??= {};
         // eslint-disable-next-line camelcase
         deleteOptions.qs.dcl_enabled = '1';
@@ -1104,13 +1138,16 @@ export class RokuDeploy {
 
     public async captureScreenshot(options: CaptureScreenshotOptions): Promise<CaptureScreenshotResult> {
         options = { ...this.options, ...options } as CaptureScreenshotOptions;
-        this.checkRequiredOptions(options, ['host', 'password']);
+        this.checkRequiredOptions(options, ['device', 'password']);
         this.validatePort(options.packagePort, 'packagePort');
         this.validateTimeout(options.timeout);
 
+        const deviceConfig = this.resolveDevice(options.device);
+        const host = this.getHost(deviceConfig);
+
         // Ask for the device to make an image
         let createScreenshotResult = await this.doPostRequest({
-            ...this.generateBaseRequestOptions('plugin_inspect', options),
+            ...this.generateBaseRequestOptions('plugin_inspect', host, options),
             formData: {
                 mysubmit: 'Screenshot',
                 archive: ''
@@ -1124,7 +1161,7 @@ export class RokuDeploy {
             throw new Error('No screenshot url returned from device');
         }
 
-        const requestParams = this.generateBaseRequestOptions(imageUrlOnDevice, options);
+        const requestParams = this.generateBaseRequestOptions(imageUrlOnDevice, host, options);
 
         // Always download to buffer
         const buffer = await this.downloadToBuffer(requestParams);
@@ -1235,6 +1272,78 @@ export class RokuDeploy {
     }
 
     /**
+     * Resolve a DeviceOption (string or DeviceConfig) to a concrete DeviceConfig.
+     * If string, looks up in the devices registry. If object, validates and returns.
+     */
+    private resolveDevice(device: DeviceOption): DeviceConfig {
+        // String = registry lookup
+        if (typeof device === 'string') {
+            const entry = this.options.devices?.[device];
+            if (!entry) {
+                throw new Error(`Device '${device}' not found in devices registry`);
+            }
+            return this.extractDeviceConfig(entry);
+        }
+        // Object = inline config, validate and return
+        this.validateDeviceConfig(device);
+        return device;
+    }
+
+    /**
+     * Validate that a device config has exactly one identifier (host, esn, id, or instanceUrl).
+     */
+    private validateDeviceConfig(config: DeviceConfig): void {
+        const identifiers = [
+            (config as any).host,
+            (config as any).esn,
+            (config as any).id,
+            (config as any).instanceUrl
+        ].filter(Boolean);
+
+        if (identifiers.length === 0) {
+            throw new InvalidOptionError(
+                'Device must specify host, esn, id, or instanceUrl',
+                { optionName: 'device' }
+            );
+        }
+        if (identifiers.length > 1) {
+            throw new InvalidOptionError(
+                'Device cannot specify multiple identifiers (host, esn, id, instanceUrl)',
+                { optionName: 'device' }
+            );
+        }
+    }
+
+    /**
+     * Extract a DeviceConfig from a DeviceRegistryEntry.
+     */
+    private extractDeviceConfig(entry: DeviceRegistryEntry): DeviceConfig {
+        if (entry.host) {
+            return { host: entry.host };
+        }
+        if (entry.esn) {
+            return { esn: entry.esn, rceToken: entry.rceToken };
+        }
+        if (entry.id) {
+            return { id: entry.id, rceToken: entry.rceToken };
+        }
+        if (entry.instanceUrl) {
+            return { instanceUrl: entry.instanceUrl, rceToken: entry.rceToken };
+        }
+        throw new Error('Device registry entry has no valid identifier (host, esn, id, or instanceUrl)');
+    }
+
+    /**
+     * Get the host from a resolved DeviceConfig. Throws if it's an RCE device.
+     */
+    private getHost(deviceConfig: DeviceConfig): string {
+        if (isRceDeviceConfig(deviceConfig)) {
+            throw new Error('RCE devices are not yet supported');
+        }
+        return deviceConfig.host;
+    }
+
+    /**
      * Validate that a port number is a valid integer between 1 and 65535
      */
     private validatePort(value: unknown, name: string): void {
@@ -1286,10 +1395,15 @@ export class RokuDeploy {
      */
     public async validateDeveloperPassword(options: ValidateDeveloperPasswordOptions): Promise<boolean> {
         options = { ...this.options, ...options } as ValidateDeveloperPasswordOptions;
+        this.checkRequiredOptions(options, ['device', 'password']);
+
+        const deviceConfig = this.resolveDevice(options.device);
+        const host = this.getHost(deviceConfig);
+
         const username = options.username ?? 'rokudev';
         const port = options.port ?? 80;
         const timeout = options.timeout ?? 3000;
-        const url = `http://${options.host}:${port}/plugin_install`;
+        const url = `http://${host}:${port}/plugin_install`;
 
         let response: Response;
         try {
@@ -1301,7 +1415,7 @@ export class RokuDeploy {
             });
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err);
-            throw new DeviceUnreachableError(`Device ${options.host} was unreachable: ${message}`, err);
+            throw new DeviceUnreachableError(`Device ${host} was unreachable: ${message}`, err);
         }
 
         if (response.status === 200) {
@@ -1310,7 +1424,7 @@ export class RokuDeploy {
         if (response.status === 401) {
             return false;
         }
-        throw new InvalidDeviceResponseCodeError(`Unexpected status ${response.status} from device at ${options.host}`, response as any);
+        throw new InvalidDeviceResponseCodeError(`Unexpected status ${response.status} from device at ${host}`, response as any);
     }
 
     /**
@@ -1322,18 +1436,20 @@ export class RokuDeploy {
     public async getDeviceInfo(options?: GetDeviceInfoOptions): Promise<DeviceInfoRaw>;
     public async getDeviceInfo(options: GetDeviceInfoOptions) {
         options = { ...this.options, ...options } as GetDeviceInfoOptions;
-        this.checkRequiredOptions(options, ['host']);
+        this.checkRequiredOptions(options, ['device']);
         this.validatePort(options.ecpPort, 'ecpPort');
         this.validateTimeout(options.timeout);
+
+        const deviceConfig = this.resolveDevice(options.device);
+        let host = this.getHost(deviceConfig);
 
         // Set defaults
         const ecpPort = options.ecpPort ?? RokuDeploy.defaults.ecpPort;
         const timeout = options.timeout ?? RokuDeploy.defaults.timeout;
 
         //if the host is a DNS name, look up the IP address
-        let host = options.host;
         try {
-            host = await util.dnsLookup(options.host);
+            host = await util.dnsLookup(host);
         } catch (e) {
             //try using the host as-is (it'll probably fail...)
         }
@@ -1451,7 +1567,7 @@ export class RokuDeploy {
      */
     public async getDevId(options?: GetDevIdOptions): Promise<GetDevIdResult> {
         options = { ...this.options, ...options } as GetDevIdOptions;
-        this.checkRequiredOptions(options, ['host']);
+        this.checkRequiredOptions(options, ['device']);
         const deviceInfo = await this.getDeviceInfo(options);
         this.logger.debug('Found dev id:', deviceInfo['keyed-developer-id']);
         return { devId: deviceInfo['keyed-developer-id'] };
@@ -1485,7 +1601,10 @@ export class RokuDeploy {
 
     public async rebootDevice(options: RebootDeviceOptions) {
         options = { ...this.options, ...options } as RebootDeviceOptions;
-        this.checkRequiredOptions(options, ['host', 'password']);
+        this.checkRequiredOptions(options, ['device', 'password']);
+
+        const deviceConfig = this.resolveDevice(options.device);
+        const host = this.getHost(deviceConfig);
 
         // Get device info to check software version
         const deviceInfo = await this.getDeviceInfo(options);
@@ -1504,7 +1623,7 @@ export class RokuDeploy {
         }
 
         return this.doPostRequest({
-            ...this.generateBaseRequestOptions('plugin_swup', options),
+            ...this.generateBaseRequestOptions('plugin_swup', host, options),
             formData: {
                 mysubmit: 'Reboot',
                 archive: ''
@@ -1514,7 +1633,10 @@ export class RokuDeploy {
 
     public async checkForUpdate(options: CheckForUpdateOptions) {
         options = { ...this.options, ...options } as CheckForUpdateOptions;
-        this.checkRequiredOptions(options, ['host', 'password']);
+        this.checkRequiredOptions(options, ['device', 'password']);
+
+        const deviceConfig = this.resolveDevice(options.device);
+        const host = this.getHost(deviceConfig);
 
         // Get device info to check software version
         const deviceInfo = await this.getDeviceInfo(options);
@@ -1533,7 +1655,7 @@ export class RokuDeploy {
         }
 
         return this.doPostRequest({
-            ...this.generateBaseRequestOptions('plugin_swup', options),
+            ...this.generateBaseRequestOptions('plugin_swup', host, options),
             formData: {
                 mysubmit: 'CheckUpdate',
                 archive: ''
@@ -1577,22 +1699,7 @@ export interface RokuPlugin {
 }
 export type RokuPackage = RokuPlugin;
 
-export interface ListSideloadedPluginsOptions {
-    /**
-     * The IP address or hostname of the target Roku device.
-     * @example '192.168.1.21'
-     */
-    host: string;
-
-    /**
-     * The password for logging in to the developer portal on the target Roku device
-     */
-    password: string;
-
-    /**
-     * The username for logging in to the developer portal on the target Roku device. Defaults to `'rokudev'`
-     */
-    username?: string;
+export interface ListSideloadedPluginsOptions extends BaseRequestOptions {
 }
 
 enum RokuMessageType {
@@ -1667,8 +1774,8 @@ export interface GetDeviceInfoOptions extends BaseEcpOptions {
 }
 
 export interface ValidateDeveloperPasswordOptions {
-    /** The hostname or IP of the Roku device */
-    host: string;
+    /** The target device. Can be a registry name (string) or an inline device config. */
+    device: DeviceOption;
 
     /** The developer password to check */
     password: string;
@@ -1763,7 +1870,7 @@ export interface PackageUploadOverridesOptions {
 }
 
 export interface BaseRequestOptions {
-    host: string;
+    device: DeviceOption;
     username?: string;
     password: string;
     packagePort?: number;
@@ -1771,7 +1878,7 @@ export interface BaseRequestOptions {
 }
 
 export interface BaseEcpOptions {
-    host: string;
+    device: DeviceOption;
     ecpPort?: number;
     timeout?: number;
 }

--- a/src/RokuDeployOptions.ts
+++ b/src/RokuDeployOptions.ts
@@ -1,4 +1,27 @@
 import type { Logger, LogLevel, LogLevelNumeric } from '@rokucommunity/logger';
+import type { DeviceOption } from './DeviceConfig';
+
+/**
+ * A device entry in the devices registry.
+ * Contains device addressing info plus optional per-device settings.
+ */
+export interface DeviceRegistryEntry {
+    // One of these identifies the device
+    host?: string;
+    esn?: string;
+    id?: string;
+    instanceUrl?: string;
+
+    // Optional RCE token (can be injected at runtime)
+    rceToken?: string;
+
+    // Optional per-device settings
+    password?: string;
+    username?: string;
+    packagePort?: number;
+    ecpPort?: number;
+    timeout?: number;
+}
 
 /**
  * Options that can be passed to the RokuDeploy constructor to set defaults
@@ -10,10 +33,16 @@ export interface RokuDeployConstructorOptions {
      */
     logger?: Logger;
     /**
-     * The IP address or hostname of the target Roku device.
-     * @example '192.168.1.21'
+     * The target device. Can be a registry name (string) or an inline device config.
+     * @example 'living-room'
+     * @example { host: '192.168.1.21' }
      */
-    host?: string;
+    device?: DeviceOption;
+    /**
+     * A registry of named devices. Keys are device names, values are device configurations.
+     * @example { 'living-room': { host: '192.168.1.21', password: 'aaaa' } }
+     */
+    devices?: Record<string, DeviceRegistryEntry>;
     /**
      * The password for logging in to the developer portal on the target Roku device
      */
@@ -80,10 +109,17 @@ export interface RokuDeployOptions {
     stagingDir?: string;
 
     /**
-     * The IP address or hostname of the target Roku device.
-     * @example '192.168.1.21'
+     * The target device. Can be a registry name (string) or an inline device config.
+     * @example 'living-room'
+     * @example { host: '192.168.1.21' }
      */
-    host?: string;
+    device?: DeviceOption;
+
+    /**
+     * A registry of named devices. Keys are device names, values are device configurations.
+     * @example { 'living-room': { host: '192.168.1.21', password: 'aaaa' } }
+     */
+    devices?: Record<string, DeviceRegistryEntry>;
 
     /**
      * The port that should be used when installing the package. Defaults to 80.

--- a/src/device.spec.ts
+++ b/src/device.spec.ts
@@ -46,10 +46,10 @@ describe('device', function device() {
     //fast instead of hanging the full old 120s.
     this.timeout(10_000);
 
-    //host/password are required by every v4 device method; the `before` hook guarantees they're set,
-    //so narrow the type here (they're `string | undefined` on the base RokuDeployOptions) to avoid
-    //spreading an optional host/password into methods that require them.
-    let options: rokuDeploy.RokuDeployOptions & { host: string; password: string };
+    //device/password are required by every v4 device method; the `before` hook guarantees they're set,
+    //so narrow the type here (they're optional on the base RokuDeployOptions) to avoid
+    //spreading an optional device/password into methods that require them.
+    let options: rokuDeploy.RokuDeployOptions & { device: { host: string }; password: string };
     //v4 has no top-level exported functions; every call goes through a RokuDeploy instance
     let rd: RokuDeploy;
     //v4 RokuDeployOptions no longer carries the rekey package path (old `rekeySignedPackage`); track it separately
@@ -71,7 +71,7 @@ describe('device', function device() {
         process.chdir(rootDir);
         rd = new RokuDeploy();
         options = {
-            host: HOST,
+            device: { host: HOST },
             password: PASSWORD,
             devId: 'c6fdc2019903ac3332f624b0b2c2fe2c733c3e74',
             signingPassword: 'drRCEVWP/++K5TYnTtuAfQ=='
@@ -136,7 +136,7 @@ describe('device', function device() {
      * Return the archiveFileNames of only the installed component libraries (DCLs)
      */
     async function getInstalledComponentLibraryFileNames() {
-        const packages = await rd.listSideloadedPlugins({ host: options.host, password: options.password });
+        const packages = await rd.listSideloadedPlugins({ device: options.device, password: options.password });
         return packages.filter(x => x.appType === 'dcl').map(x => x.archiveFileName);
     }
 
@@ -244,7 +244,7 @@ describe('device', function device() {
             options.password = 'NOT_THE_PASSWORD';
             await expectThrowsAsync(
                 rd.sideload({ ...options, dir: rootDir }),
-                `Unauthorized. Please verify credentials for host '${options.host}'`
+                `Unauthorized. Please verify credentials for host '${options.device.host}'`
             );
         });
     });
@@ -264,9 +264,9 @@ describe('device', function device() {
         //stage+zip+sideload followed by `createSignedPackage`; confirm the device is left rekeyed and
         //the returned pkg path exists.
         it('works', async () => {
-            await rd.deleteDevChannel({ host: options.host, password: options.password });
+            await rd.deleteDevChannel({ device: options.device, password: options.password });
             await rd.rekeyDevice({
-                host: options.host,
+                device: options.device,
                 password: options.password,
                 pkg: rekeySignedPackage,
                 signingPassword: options.signingPassword,
@@ -278,7 +278,7 @@ describe('device', function device() {
             await rd.zip({ dir: staged, out: zipPath, files: options.files });
             await rd.sideload({ ...options, zip: zipPath });
             const { pkgPath } = await rd.createSignedPackage({
-                host: options.host,
+                device: options.device,
                 password: options.password,
                 signingPassword: options.signingPassword,
                 devId: options.devId,
@@ -291,7 +291,7 @@ describe('device', function device() {
     describe('validateDeveloperPassword', () => {
         it('returns true when the password is correct', async () => {
             const result = await rd.validateDeveloperPassword({
-                host: options.host,
+                device: options.device,
                 password: options.password
             });
             assert.strictEqual(result, true);
@@ -299,7 +299,7 @@ describe('device', function device() {
 
         it('returns false when the password is wrong', async () => {
             const result = await rd.validateDeveloperPassword({
-                host: options.host,
+                device: options.device,
                 password: 'NOT_THE_PASSWORD'
             });
             assert.strictEqual(result, false);
@@ -308,7 +308,7 @@ describe('device', function device() {
         it('throws DeviceUnreachableError for an offline host', async () => {
             await expectThrowsAsync(async () => {
                 await rd.validateDeveloperPassword({
-                    host: '192.168.254.254',
+                    device: { host: '192.168.254.254' },
                     password: 'aaaa',
                     timeout: 2000
                 });
@@ -318,13 +318,13 @@ describe('device', function device() {
 
     describe('getDeviceInfo', () => {
         it('works', async () => {
-            const info = await rd.getDeviceInfo({ host: options.host });
+            const info = await rd.getDeviceInfo({ device: options.device });
             assert.ok(info);
             assert.ok(info['software-version']);
         });
 
         it('normalizes types when enhanced', async () => {
-            const info = await rd.getDeviceInfo({ host: options.host, enhance: true });
+            const info = await rd.getDeviceInfo({ device: options.device, enhance: true });
             assert.ok(info.softwareVersion);
             assert.strictEqual(typeof info.supportsEthernet, 'boolean');
         });
@@ -339,14 +339,14 @@ describe('device', function device() {
 
     describe('getEcpNetworkAccessMode', () => {
         it('works', async () => {
-            const mode = await rd.getEcpNetworkAccessMode({ host: options.host });
+            const mode = await rd.getEcpNetworkAccessMode({ device: options.device });
             assert.ok([undefined, 'enabled', 'disabled', 'limited', 'permissive'].includes(mode));
         });
     });
 
     describe('pressHomeButton', () => {
         it('works', async () => {
-            await rd.keyPress({ host: options.host, key: 'home' });
+            await rd.keyPress({ device: options.device, key: 'home' });
         });
     });
 
@@ -381,7 +381,7 @@ describe('device', function device() {
 
             //start listening on the debug console BEFORE deploying so we don't miss the marker.
             //(the socket's teardown is registered in `cleanups` and drained by afterEach)
-            const sawMarker = waitForConsoleOutput(options.host, marker, 45000);
+            const sawMarker = waitForConsoleOutput(options.device.host, marker, 45000);
 
             await rd.sideload({ ...options, dir: rootDir });
 
@@ -389,11 +389,11 @@ describe('device', function device() {
             await sawMarker;
 
             //belt-and-suspenders: confirm the dev channel is the active app via ECP
-            const activeApp = await getActiveApp(options.host);
+            const activeApp = await getActiveApp(options.device.host);
             assert.ok(/dev/i.test(activeApp), `expected the dev channel to be the active app, got: ${activeApp}`);
 
             //v4 captureScreenshot returns { buffer, filePath? }; pass `out: true` to also save to disk so we can assert the path exists
-            const result = await rd.captureScreenshot({ host: options.host, password: options.password, out: true });
+            const result = await rd.captureScreenshot({ device: options.device, password: options.password, out: true });
             expectPathExists(result.filePath);
         });
     });
@@ -401,20 +401,20 @@ describe('device', function device() {
     describe('convertToSquashfs', () => {
         it('works', async () => {
             await rd.sideload({ ...options, dir: rootDir });
-            await rd.convertToSquashfs({ host: options.host, password: options.password });
+            await rd.convertToSquashfs({ device: options.device, password: options.password });
         });
     });
 
     describe('deleteAllComponentLibraries', () => {
         it('works', async () => {
-            await rd.deleteAllComponentLibraries({ host: options.host, password: options.password });
+            await rd.deleteAllComponentLibraries({ device: options.device, password: options.password });
         });
     });
 
     describe('deleteInstalledChannel', () => {
         it('works', async () => {
             await rd.sideload({ ...options, dir: rootDir });
-            await rd.deleteDevChannel({ host: options.host, password: options.password });
+            await rd.deleteDevChannel({ device: options.device, password: options.password });
         });
     });
 
@@ -427,7 +427,7 @@ describe('device', function device() {
             //test-timeout fired first.
             await rd.rebootDevice({ ...options, timeout: REQUEST_TIMEOUT });
             //wait until the device is reachable again so the next test doesn't run mid-reboot
-            await waitForDeviceOnline(options.host);
+            await waitForDeviceOnline(options.device.host);
         });
     });
 
@@ -448,7 +448,7 @@ describe('device', function device() {
 
             //we don't know which device the suite runs against, so ask it what firmware it has and
             //decide up-front whether checkForUpdate should succeed or be rejected by the version gate.
-            const softwareVersion = (await rd.getDeviceInfo({ host: options.host, timeout: REQUEST_TIMEOUT }))['software-version'];
+            const softwareVersion = (await rd.getDeviceInfo({ device: options.device, timeout: REQUEST_TIMEOUT }))['software-version'];
             const supported = !!softwareVersion && semver.gte(semver.coerce(softwareVersion), MIN_FIRMWARE);
 
             if (supported) {
@@ -456,7 +456,7 @@ describe('device', function device() {
                 const result = await rd.checkForUpdate(reqOptions);
                 assert.ok(result, 'expected a response from checkForUpdate');
                 //checkForUpdate can trigger a reboot; make sure the device is back before the next test
-                await waitForDeviceOnline(options.host);
+                await waitForDeviceOnline(options.device.host);
             } else {
                 console.log(`[checkForUpdate] device firmware ${softwareVersion} < ${MIN_FIRMWARE}; expecting UnsupportedFirmwareVersionError`);
                 let thrown: Error;
@@ -486,7 +486,7 @@ describe('device', function device() {
             await installChannel();
 
             //the channel should now be installed
-            expect(countByType(await rd.listSideloadedPlugins({ host: options.host, password: options.password }))).to.eql({
+            expect(countByType(await rd.listSideloadedPlugins({ device: options.device, password: options.password }))).to.eql({
                 channels: 1,
                 complibs: 0
             });
@@ -494,7 +494,7 @@ describe('device', function device() {
             await rd.deleteAllSideloadedPlugins(options);
 
             //nothing should be installed anymore
-            expect(await rd.listSideloadedPlugins({ host: options.host, password: options.password })).to.eql([]);
+            expect(await rd.listSideloadedPlugins({ device: options.device, password: options.password })).to.eql([]);
         });
 
         it('deletes a single component library', async () => {
@@ -504,7 +504,7 @@ describe('device', function device() {
             await installComponentLibrary('a');
 
             //the complib should now be installed
-            expect(countByType(await rd.listSideloadedPlugins({ host: options.host, password: options.password }))).to.eql({
+            expect(countByType(await rd.listSideloadedPlugins({ device: options.device, password: options.password }))).to.eql({
                 channels: 0,
                 complibs: 1
             });
@@ -512,7 +512,7 @@ describe('device', function device() {
             await rd.deleteAllSideloadedPlugins(options);
 
             //nothing should be installed anymore
-            expect(await rd.listSideloadedPlugins({ host: options.host, password: options.password })).to.eql([]);
+            expect(await rd.listSideloadedPlugins({ device: options.device, password: options.password })).to.eql([]);
         });
 
         it('deletes a channel and a component library together', async () => {
@@ -523,7 +523,7 @@ describe('device', function device() {
             await installComponentLibrary('complib1');
 
             //both should now be installed
-            expect(countByType(await rd.listSideloadedPlugins({ host: options.host, password: options.password }))).to.eql({
+            expect(countByType(await rd.listSideloadedPlugins({ device: options.device, password: options.password }))).to.eql({
                 channels: 1,
                 complibs: 1
             });
@@ -531,7 +531,7 @@ describe('device', function device() {
             await rd.deleteAllSideloadedPlugins(options);
 
             //nothing should be installed anymore
-            expect(await rd.listSideloadedPlugins({ host: options.host, password: options.password })).to.eql([]);
+            expect(await rd.listSideloadedPlugins({ device: options.device, password: options.password })).to.eql([]);
         });
 
         it('deletes a channel and two component libraries together', async () => {
@@ -543,7 +543,7 @@ describe('device', function device() {
             await installComponentLibrary('complib2');
 
             //all three should now be installed
-            expect(countByType(await rd.listSideloadedPlugins({ host: options.host, password: options.password }))).to.eql({
+            expect(countByType(await rd.listSideloadedPlugins({ device: options.device, password: options.password }))).to.eql({
                 channels: 1,
                 complibs: 2
             });
@@ -551,7 +551,7 @@ describe('device', function device() {
             await rd.deleteAllSideloadedPlugins(options);
 
             //nothing should be installed anymore
-            expect(await rd.listSideloadedPlugins({ host: options.host, password: options.password })).to.eql([]);
+            expect(await rd.listSideloadedPlugins({ device: options.device, password: options.password })).to.eql([]);
         });
     });
 
@@ -710,14 +710,14 @@ describe('device', function device() {
             });
 
             //everything should be installed now: the channel plus all five component libraries
-            expect(countByType(await rd.listSideloadedPlugins({ host: options.host, password: options.password }))).to.eql({
+            expect(countByType(await rd.listSideloadedPlugins({ device: options.device, password: options.password }))).to.eql({
                 channels: 1,
                 complibs: LIB_DEPENDENCY_CHAIN.length
             });
 
             //delete the app (the dev channel). the list afterward proves the request didn't hang the socket.
-            await rd.deleteDevChannel({ host: options.host, password: options.password });
-            expect(countByType(await rd.listSideloadedPlugins({ host: options.host, password: options.password }))).to.eql({
+            await rd.deleteDevChannel({ device: options.device, password: options.password });
+            expect(countByType(await rd.listSideloadedPlugins({ device: options.device, password: options.password }))).to.eql({
                 channels: 0,
                 complibs: LIB_DEPENDENCY_CHAIN.length
             });
@@ -725,8 +725,8 @@ describe('device', function device() {
             //delete the app AGAIN when there is no dev channel installed. this redundant delete is a
             //suspected trigger for the flaky socket hangup, so exercise it explicitly and confirm the
             //very next request still succeeds.
-            await rd.deleteDevChannel({ host: options.host, password: options.password });
-            expect(countByType(await rd.listSideloadedPlugins({ host: options.host, password: options.password }))).to.eql({
+            await rd.deleteDevChannel({ device: options.device, password: options.password });
+            expect(countByType(await rd.listSideloadedPlugins({ device: options.device, password: options.password }))).to.eql({
                 channels: 0,
                 complibs: LIB_DEPENDENCY_CHAIN.length
             });
@@ -738,7 +738,7 @@ describe('device', function device() {
             let expectedRemaining = remaining.length;
             for (const fileName of remaining) {
                 await rd.deleteComponentLibrary({
-                    host: options.host,
+                    device: options.device,
                     password: options.password,
                     fileName: fileName
                 });
@@ -750,16 +750,16 @@ describe('device', function device() {
             }
 
             //everything is gone
-            expect(await rd.listSideloadedPlugins({ host: options.host, password: options.password })).to.eql([]);
+            expect(await rd.listSideloadedPlugins({ device: options.device, password: options.password })).to.eql([]);
 
             //one more delete against an already-empty device to be sure the "delete when nothing is
             //installed" path doesn't hang the socket for the next caller
             await rd.deleteComponentLibrary({
-                host: options.host,
+                device: options.device,
                 password: options.password,
                 fileName: remaining[0] ?? 'nonexistent.zip'
             });
-            expect(await rd.listSideloadedPlugins({ host: options.host, password: options.password })).to.eql([]);
+            expect(await rd.listSideloadedPlugins({ device: options.device, password: options.password })).to.eql([]);
         });
     });
 
@@ -829,7 +829,7 @@ describe('device', function device() {
             });
 
             //sanity: channel + all three complibs are present
-            expect(countByType(await rd.listSideloadedPlugins({ host: options.host, password: options.password }))).to.eql({
+            expect(countByType(await rd.listSideloadedPlugins({ device: options.device, password: options.password }))).to.eql({
                 channels: 1,
                 complibs: 3
             });
@@ -839,10 +839,10 @@ describe('device', function device() {
         //complibs (deleteComponentLibrary by their captured archiveFileName).
         async function deletePiece(name: string) {
             if (name === APP) {
-                await rd.deleteDevChannel({ host: options.host, password: options.password, timeout: REQUEST_TIMEOUT });
+                await rd.deleteDevChannel({ device: options.device, password: options.password, timeout: REQUEST_TIMEOUT });
             } else {
                 await rd.deleteComponentLibrary({
-                    host: options.host,
+                    device: options.device,
                     password: options.password,
                     fileName: libFileNames[name]
                 });
@@ -876,21 +876,21 @@ describe('device', function device() {
                 console.log(`[reboot-hunt]   full set installed (charlie, beta, alpha, app)`);
 
                 //baseline uptime; a later read that is LOWER means the device rebooted in between
-                let priorUptime = await getDeviceUptime(options.host);
+                let priorUptime = await getDeviceUptime(options.device.host);
 
                 for (let step = 0; step < order.length; step++) {
                     const piece = order[step];
                     console.log(`[reboot-hunt]   step ${step + 1}/${order.length}: deleting "${piece}"...`);
                     await deletePiece(piece);
 
-                    const nowUptime = await getDeviceUptime(options.host);
+                    const nowUptime = await getDeviceUptime(options.device.host);
                     //undefined = device unreachable (very likely mid-reboot); a drop in uptime = it rebooted
                     const rebooted = nowUptime === undefined || (priorUptime !== undefined && nowUptime < priorUptime);
                     if (rebooted) {
                         console.log(`[reboot-hunt]   !! REBOOT DETECTED after deleting "${piece}" (step ${step + 1}) in order [${order.join(', ')}]; waiting for device to come back...`);
                         rebootTriggers.push({ order: order, afterDeleting: piece, step: step + 1 });
                         //let the device fully recover before the next permutation so we don't test mid-reboot
-                        await waitForDeviceOnline(options.host);
+                        await waitForDeviceOnline(options.device.host);
                         console.log(`[reboot-hunt]   device back online; moving to next permutation`);
                         break;
                     }
@@ -933,7 +933,7 @@ describe('device', function device() {
             let expectedRemaining = fileNames.length;
             for (const target of fileNames) {
                 await rd.deleteComponentLibrary({
-                    host: options.host,
+                    device: options.device,
                     password: options.password,
                     fileName: target
                 });
@@ -963,7 +963,7 @@ describe('device', function device() {
             //delete just the first complib
             const [toDelete, toKeep] = fileNames;
             await rd.deleteComponentLibrary({
-                host: options.host,
+                device: options.device,
                 password: options.password,
                 fileName: toDelete
             });
@@ -993,14 +993,14 @@ describe('device', function device() {
             //delete the complibs one by one
             for (const fileName of await getInstalledComponentLibraryFileNames()) {
                 await rd.deleteComponentLibrary({
-                    host: options.host,
+                    device: options.device,
                     password: options.password,
                     fileName: fileName
                 });
             }
 
             //all complibs gone, but the channel should still be installed
-            const packages = await rd.listSideloadedPlugins({ host: options.host, password: options.password });
+            const packages = await rd.listSideloadedPlugins({ device: options.device, password: options.password });
             expect(packages.filter(x => x.appType === 'dcl')).to.eql([]);
             expect(packages.filter(x => x.appType === 'channel')).to.have.lengthOf(1);
 
@@ -1092,7 +1092,7 @@ async function waitForDeviceOnline(host: string, timeoutMs = 120_000, intervalMs
     let lastError: Error;
     while (Date.now() < deadline) {
         try {
-            await helperRd.getDeviceInfo({ host: host, timeout: intervalMs });
+            await helperRd.getDeviceInfo({ device: { host: host }, timeout: intervalMs });
             //a successful device-info query means ECP is up and the device is responsive again
             return;
         } catch (e) {
@@ -1110,7 +1110,7 @@ async function waitForDeviceOnline(host: string, timeoutMs = 120_000, intervalMs
  */
 async function getDeviceUptime(host: string): Promise<number | undefined> {
     try {
-        const info = await helperRd.getDeviceInfo({ host: host, enhance: true, timeout: 15_000 });
+        const info = await helperRd.getDeviceInfo({ device: { host: host }, enhance: true, timeout: 15_000 });
         //`enhance` coerces uptime to a number; guard anyway in case a device omits it
         return typeof info.uptime === 'number' ? info.uptime : undefined;
     } catch {


### PR DESCRIPTION
## Summary

Implements the unified `device` option (#311) to replace the flat `host` string. This allows addressing devices via:
- Local network (IP, hostname, `.local`)
- RCE (Roku Cloud Emulator) via ESN, ID, or instance URL (throws "not yet supported" for now)
- Named device registry lookup from constructor options

### Key Changes

**New Types (`src/DeviceConfig.ts`):**
- `LocalDeviceConfig` - for local network devices (`{ host: string }`)
- `RceDeviceConfig` - for RCE devices (by ESN, ID, or instance URL)
- `DeviceOption` - user input type (string for registry lookup, or inline config)
- Type guards: `isLocalDeviceConfig()`, `isRceDeviceConfig()`

**Options Changes (`src/RokuDeployOptions.ts`):**
- Added `device?: DeviceOption` to `RokuDeployOptions` and `RokuDeployConstructorOptions`
- Added `devices?: Record<string, DeviceRegistryEntry>` for named device registry
- Removed `host` property from all options interfaces

**RokuDeploy Class:**
- Added `resolveDevice()` - resolves `DeviceOption` to `DeviceConfig` (handles registry lookup)
- Added `validateDeviceConfig()` - ensures exactly one identifier is present
- Added `extractDeviceConfig()` - extracts device config from registry entry
- Added `getHost()` - extracts host from device config (throws for RCE devices)
- Updated all device-connected methods to use `device` instead of `host`

### Migration

**Before:**
```typescript
await rokuDeploy.sideload({
  host: '192.168.1.100',
  password: 'aaaa',
  zip: 'app.zip'
});
```

**After:**
```typescript
await rokuDeploy.sideload({
  device: { host: '192.168.1.100' },
  password: 'aaaa',
  zip: 'app.zip'
});
```

**With device registry:**
```typescript
const rd = new RokuDeploy({
  devices: {
    'living-room': { host: '192.168.1.100', password: 'aaaa' }
  }
});
await rd.sideload({ device: 'living-room', zip: 'app.zip' });
```

### Methods Updated
- `sideload`, `convertToSquashfs`, `rekeyDevice`, `createSignedPackage`
- `deleteDevChannel`, `deleteAllSideloadedPlugins`, `deleteComponentLibrary`, `deleteAllComponentLibraries`
- `listSideloadedPlugins`, `captureScreenshot`
- `sendKeyEvent`, `keyPress`, `keyUp`, `keyDown`, `sendText`, `closeChannel`
- `getDeviceInfo`, `getEcpNetworkAccessMode`, `getDevId`
- `rebootDevice`, `checkForUpdate`, `validateDeveloperPassword`

### Deferred
- CLI updates (`--device`, `--host` flags) - will be in a follow-up PR
- RCE device support - throws "RCE devices are not yet supported" for now

---
Closes #311
