### PR TITLE
Fix write EPIPE when uploading large zips through digest auth

### DIFF
--- a/src/device.spec.ts
+++ b/src/device.spec.ts
@@ -208,6 +208,76 @@ describe('device', function device() {
         });
     });
 
+    describe('large zip uploads', function largeZipUploads() {
+        //a large upload takes several seconds per digest-auth leg on wifi, and publish() may attempt
+        //Replace + Install; keep this generous
+        this.timeout(120_000);
+
+        //Large enough that the multipart body cannot fit in the OS socket buffers, so the upload is
+        //still mid-write when the device responds to the request. Random bytes are incompressible, so
+        //the zip stays this size instead of deflating away.
+        const LARGE_FILE_SIZE = 10 * 1024 * 1024;
+
+        it('publishes a large channel zip', async () => {
+            //bulk the standard test channel up with a large incompressible asset
+            fsExtra.outputFileSync(s`${rootDir}/assets/noise.bin`, crypto.randomBytes(LARGE_FILE_SIZE));
+
+            await rokuDeploy.createPackage({
+                ...options,
+                files: ['manifest', 'source/**/*', 'components/**/*', 'assets/**/*']
+            });
+            expect(fsExtra.statSync(rokuDeploy.rokuDeploy.getOutputZipFilePath(options)).size).to.be.greaterThan(LARGE_FILE_SIZE);
+
+            const response = await rokuDeploy.publish(options);
+            assert.equal(response.message, 'Successful deploy');
+        });
+
+        //Mirrors roku-debug's component-library launch flow: delete every sideloaded plugin, then
+        //install a complib whose zip is several megabytes (like a real-world complib)
+        it('installs a large component library after deleting all sideloaded plugins', async () => {
+            //start clean, like roku-debug does at launch
+            await rokuDeploy.rokuDeploy.deleteAllSideloadedPlugins(options);
+
+            const libName = 'largecomplib';
+            const libRootDir = `${tempDir}/${libName}`;
+            writeFiles(libRootDir, [
+                ['manifest', undent`
+                    title=${libName}
+                    sg_component_libs_provided=${libName}
+                `],
+                [`components/${libName}.xml`, undent`
+                    <component name="${libName}">
+                        <!-- ${COMPLIB_PADDING} -->
+                    </component>
+                `]
+            ]);
+            //bulk the complib up with a large incompressible asset
+            fsExtra.outputFileSync(s`${libRootDir}/assets/noise.bin`, crypto.randomBytes(LARGE_FILE_SIZE));
+
+            await rokuDeploy.rokuDeploy.createPackage({
+                ...options,
+                rootDir: libRootDir,
+                stagingDir: `${stagingDir}-${libName}`,
+                outDir: outDir,
+                outFile: libName,
+                files: ['manifest', 'components/**/*', 'assets/**/*']
+            });
+            const response = await rokuDeploy.rokuDeploy.publish({
+                ...options,
+                appType: 'dcl',
+                outDir: outDir,
+                outFile: libName
+            });
+            assert.equal(response.message, 'Successful deploy');
+
+            //the complib should now be installed on the device
+            expect(await getInstalledComponentLibraryFileNames()).to.have.lengthOf(1);
+
+            //clean up
+            await rokuDeploy.rokuDeploy.deleteAllSideloadedPlugins(options);
+        });
+    });
+
     describe('deployAndSignPackage', () => {
         it('works', async function deployAndSignPackageWorks() {
             this.timeout(12_000);

--- a/src/request.spec.ts
+++ b/src/request.spec.ts
@@ -410,6 +410,22 @@ describe('request (needle shim)', () => {
             expect(authorization).to.include('uri="/plugin_install?dcl_enabled=1"');
         });
 
+        it('computes the Authorization header with an empty password when none was supplied', async () => {
+            const calls = stubPostSequence([
+                { response: { statusCode: 401, headers: { 'www-authenticate': CHALLENGE } }, body: Buffer.alloc(0) },
+                { response: { statusCode: 200, headers: {} }, body: 'ok' }
+            ]);
+            const { error } = await callPost({
+                url: 'http://1.2.3.4:80/plugin_install',
+                auth: { user: 'rokudev' },
+                formData: { mysubmit: 'Replace' }
+            });
+            expect(error).to.be.null;
+            const authorization = calls[1].options.headers.authorization as string;
+            expect(authorization).to.match(/^Digest /);
+            expect(authorization).to.include('username="rokudev"');
+        });
+
         it('sends the real request unchanged (credentials intact) when the probe is not a 401', async () => {
             const calls = stubPostSequence([
                 { response: { statusCode: 200, headers: {} }, body: 'no auth required' }

--- a/src/request.spec.ts
+++ b/src/request.spec.ts
@@ -347,6 +347,138 @@ describe('request (needle shim)', () => {
         });
     });
 
+    describe('digest preflight for bodied POSTs', () => {
+        //needle's own digest dance sends the body on the unauthenticated first leg, which the Roku kills
+        //mid-write for large bodies (write EPIPE). The shim therefore probes bodyless first and only sends
+        //the body WITH a computed Authorization header. These tests pin that two-request sequence down.
+
+        const CHALLENGE = 'Digest qop="auth", realm="rokudev", nonce="abc123"';
+
+        /** Stub needle.post so each successive call gets the next canned result; returns the captured calls */
+        function stubPostSequence(results: Array<{ error?: any; response?: any; body?: any }>) {
+            const calls: Array<{ url: string; data: any; options: any }> = [];
+            sinon.stub(needle, 'post').callsFake(((url: string, data: any, options: any, callback: any) => {
+                const canned = results[Math.min(calls.length, results.length - 1)];
+                calls.push({ url: url, data: data, options: options });
+                process.nextTick(callback, canned.error ?? null, canned.response, canned.body);
+                return {} as any;
+            }) as any);
+            return calls;
+        }
+
+        it('sends a bodyless credential-free probe, then the real request with a computed Authorization header', async () => {
+            const calls = stubPostSequence([
+                { response: { statusCode: 401, headers: { 'www-authenticate': CHALLENGE } }, body: Buffer.alloc(0) },
+                { response: { statusCode: 200, headers: {} }, body: 'ok' }
+            ]);
+            const { error, response } = await callPost({
+                url: 'http://1.2.3.4:80/plugin_install',
+                auth: { user: 'rokudev', pass: 'aaaa', sendImmediately: false },
+                formData: { mysubmit: 'Replace' }
+            });
+            expect(calls).to.have.lengthOf(2);
+            //the probe carries no body, no multipart flag, and no credentials (needle must not answer the challenge itself)
+            expect(calls[0].data).to.be.null;
+            expect(calls[0].options.multipart).to.be.undefined;
+            expect(calls[0].options.username).to.be.undefined;
+            expect(calls[0].options.auth).to.be.undefined;
+            //the real request carries the body and the computed digest header
+            expect(calls[1].data).to.eql({ mysubmit: 'Replace' });
+            expect(calls[1].options.multipart).to.equal(true);
+            const authorization = calls[1].options.headers.authorization as string;
+            expect(authorization).to.match(/^Digest /);
+            expect(authorization).to.include('username="rokudev"');
+            expect(authorization).to.include('realm="rokudev"');
+            expect(authorization).to.include('nonce="abc123"');
+            expect(authorization).to.include('uri="/plugin_install"');
+            expect(error).to.be.null;
+            expect(response.statusCode).to.equal(200);
+        });
+
+        it('includes the query string in the digest uri', async () => {
+            const calls = stubPostSequence([
+                { response: { statusCode: 401, headers: { 'www-authenticate': CHALLENGE } }, body: Buffer.alloc(0) },
+                { response: { statusCode: 200, headers: {} }, body: 'ok' }
+            ]);
+            await callPost({
+                url: 'http://1.2.3.4:80/plugin_install',
+                qs: { dcl_enabled: '1' },
+                auth: { user: 'rokudev', pass: 'aaaa' },
+                formData: { mysubmit: 'Delete', fileName: 'a.zip' }
+            });
+            const authorization = calls[1].options.headers.authorization as string;
+            expect(authorization).to.include('uri="/plugin_install?dcl_enabled=1"');
+        });
+
+        it('sends the real request unchanged (credentials intact) when the probe is not a 401', async () => {
+            const calls = stubPostSequence([
+                { response: { statusCode: 200, headers: {} }, body: 'no auth required' }
+            ]);
+            const { error, response } = await callPost({
+                url: 'http://1.2.3.4:80/plugin_install',
+                auth: { user: 'rokudev', pass: 'aaaa' },
+                formData: { mysubmit: 'Replace' }
+            });
+            expect(calls).to.have.lengthOf(2);
+            //no Authorization header was computed, and needle's own dance stays available as the fallback
+            expect(calls[1].options.headers?.authorization).to.be.undefined;
+            expect(calls[1].options.auth).to.equal('digest');
+            expect(calls[1].options.username).to.equal('rokudev');
+            expect(error).to.be.null;
+            expect(response.statusCode).to.equal(200);
+        });
+
+        it('sends the real request unchanged when the 401 carries no challenge header', async () => {
+            const calls = stubPostSequence([
+                { response: { statusCode: 401, headers: {} }, body: Buffer.alloc(0) }
+            ]);
+            const { response } = await callPost({
+                url: 'http://1.2.3.4:80/plugin_install',
+                auth: { user: 'rokudev', pass: 'aaaa' },
+                formData: { mysubmit: 'Replace' }
+            });
+            expect(calls).to.have.lengthOf(2);
+            expect(calls[1].options.headers?.authorization).to.be.undefined;
+            //the real request's own response is what gets surfaced
+            expect(response.statusCode).to.equal(401);
+        });
+
+        it('propagates a probe failure without sending the real request', async () => {
+            const networkError = new Error('ECONNREFUSED');
+            const calls = stubPostSequence([{ error: networkError }]);
+            const { error, response } = await callPost({
+                url: 'http://1.2.3.4:80/plugin_install',
+                auth: { user: 'rokudev', pass: 'aaaa' },
+                formData: { mysubmit: 'Replace' }
+            });
+            expect(calls).to.have.lengthOf(1);
+            expect(error).to.equal(networkError);
+            expect(response).to.be.undefined;
+        });
+
+        it('does NOT preflight a bodyless POST (e.g. ECP keypress with credentials)', async () => {
+            const calls = stubPostSequence([
+                { response: { statusCode: 200, headers: {} }, body: '' }
+            ]);
+            await callPost({
+                url: 'http://1.2.3.4:8060/keypress/Home',
+                auth: { user: 'rokudev', pass: 'aaaa' }
+            });
+            expect(calls).to.have.lengthOf(1);
+        });
+
+        it('does NOT preflight a bodied POST without credentials', async () => {
+            const calls = stubPostSequence([
+                { response: { statusCode: 200, headers: {} }, body: 'ok' }
+            ]);
+            await callPost({
+                url: 'http://1.2.3.4:80/plugin_install',
+                formData: { mysubmit: 'Replace' }
+            });
+            expect(calls).to.have.lengthOf(1);
+        });
+    });
+
     describe('error passthrough', () => {
         it('forwards a needle error to the callback with undefined response/body (post)', async () => {
             const networkError = new Error('socket hang up');

--- a/src/request.ts
+++ b/src/request.ts
@@ -2,6 +2,7 @@
 import * as needle from 'needle';
 import * as urlModule from 'url';
 import type { ReadStream } from 'fs';
+import { buildDigestAuthorization, parseDigestChallenge } from './fetch';
 
 /**
  * A thin compatibility shim over `needle` that mimics the small slice of the
@@ -24,13 +25,69 @@ export class Request {
      */
     public post(params: RequestOptions, callback: RequestCallback) {
         const { url, data, needleOptions } = this.translateOptions(params, 'POST');
-        return needle.post(url, data, needleOptions, (error, response, body) => {
+        //Never let needle's own digest dance send a request body: needle sends the FULL body on the
+        //unauthenticated first leg, but the Roku answers that leg's 401 without reading the body and closes
+        //the socket. A body still being written at that moment dies with a raw `write EPIPE`, and needle
+        //fails the whole request before its 401 retry can run. (Bodies small enough to fit in the socket
+        //buffers finish writing before the close, which is why only large zips ever hit this.)
+        //`request`/`postman-request` never had this problem because they never sent the body
+        //unauthenticated: the first leg was a bodyless probe, and the body only went out WITH the
+        //Authorization header. Replicate that here for any authenticated POST that has a body.
+        if (data && needleOptions.auth === 'digest') {
+            return this.postWithDigestPreflight(url, data, needleOptions, callback);
+        }
+        return needle.post(url, data, needleOptions, this.createNeedleCallback(url, callback));
+    }
+
+    /**
+     * POST a request whose body is only ever sent WITH an Authorization header: a bodyless probe collects
+     * the device's digest challenge, we compute the `Authorization` header ourselves, and the real request
+     * goes out pre-authorized (needle sees the header and skips its own 401 dance). If the probe doesn't
+     * yield a usable challenge (endpoint not auth-protected, unexpected status), the real request is sent
+     * unchanged and needle's own 401 dance remains as the fallback.
+     */
+    private postWithDigestPreflight(url: string, data: any, needleOptions: needle.NeedleOptions, callback: RequestCallback) {
+        //probe with no body and NO credentials: we want the raw 401 challenge back, not needle answering it
+        //(which would consume the challenge before the real request could use it)
+        const probeOptions: needle.NeedleOptions = { ...needleOptions };
+        delete probeOptions.multipart;
+        delete probeOptions.username;
+        delete probeOptions.password;
+        delete probeOptions.auth;
+
+        return needle.post(url, null, probeOptions, (probeError, probeResponse) => {
+            if (probeError) {
+                return callback(probeError, undefined, undefined);
+            }
+            const authorizedOptions: needle.NeedleOptions = { ...needleOptions };
+            const challengeHeader = probeResponse?.headers?.['www-authenticate'];
+            if (probeResponse?.statusCode === 401 && typeof challengeHeader === 'string') {
+                const authorization = buildDigestAuthorization({
+                    username: needleOptions.username,
+                    password: needleOptions.password ?? '',
+                    method: 'POST',
+                    //the digest uri must match the request line, which includes any query string
+                    uri: urlModule.parse(url).path,
+                    challenge: parseDigestChallenge(challengeHeader)
+                });
+                authorizedOptions.headers = { ...authorizedOptions.headers, authorization: authorization };
+            }
+            needle.post(url, data, authorizedOptions, this.createNeedleCallback(url, callback));
+        });
+    }
+
+    /**
+     * Build the needle callback that reshapes `(error, response, body)` into the `request`-style
+     * `(error, response, body)` the rest of roku-deploy consumes.
+     */
+    private createNeedleCallback(url: string, callback: RequestCallback) {
+        return (error: Error | null, response: any, body: any) => {
             if (error) {
                 return callback(error, undefined, undefined);
             }
             const coerced = this.coerceBody(body);
             return callback(null, this.buildResponse(response, url, coerced), coerced);
-        });
+        };
     }
 
     /**


### PR DESCRIPTION
## Problem

Publishing a large zip (multi-megabyte channel or component library) fails with a raw `write EPIPE` since the migration from postman-request to needle (#282). Small zips are unaffected, so the unit and device suites never caught it. First reported while testing rokucommunity/roku-debug#323, where installing a real-world component library aborts the debug session:

```
[ERROR] [dap][session] Error installing component library 0 (roku_grandcentral.zip) {"name":"Error","message":"write EPIPE", ...}
```

## Root cause

roku-deploy uses digest auth with `sendImmediately: false`, so every request starts with an unauthenticated leg that collects the 401 challenge. needle sends the **full multipart body** on that first leg. The Roku answers the 401 without reading the body and closes the socket, so any body still being written dies with `write EPIPE`, and needle fails the request before its 401 retry can run. Bodies small enough to fit in the OS socket buffers finish writing before the close, which is why only large zips ever hit this.

request/postman-request never had this problem because they never sent the body unauthenticated: the first leg was a bodyless probe, and the body only went out WITH the Authorization header.

## Fix

Replicate that behavior in the needle shim. For any POST that has both digest credentials and a body:

1. Send a bodyless, credential-free probe to collect the `WWW-Authenticate` challenge (credentials are stripped so needle doesn't answer and consume the challenge itself).
2. Compute the `Authorization` header, reusing the existing `buildDigestAuthorization`/`parseDigestChallenge` helpers from `fetch.ts` (the digest `uri` includes the query string so it matches the request line).
3. Send the real request pre-authorized. needle sees the preset header and skips its own 401 dance.

A probe that yields no usable challenge (endpoint not auth-protected, unexpected status) falls through to the previous behavior, with needle's own dance as the fallback. Side benefit: zips are no longer uploaded twice per request.

## Tests

- Two new device tests replicate the failure: a large (10MB incompressible) channel publish, and a delete-all-then-install of a large component library, mirroring roku-debug's launch flow. Both fail with `write EPIPE` before this fix and pass after it.
- Seven new unit tests pin the preflight sequence (bodyless credential-free probe, computed Authorization with query string, non-401 fallthrough, probe error propagation, and no preflight for bodyless or credential-less POSTs).
- Full device suite passes against a real device (28 passing, reboot/update-check excluded), including publish, rekey + sign, squashfs conversion, and all delete flows.