### PR TITLE
Restore dist/Logger as a compatibility shim

### DIFF
--- a/src/Logger.spec.ts
+++ b/src/Logger.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import { LogLevel, Logger, noop } from './Logger';
+import type { RokuDeployOptions } from './RokuDeployOptions';
+
+describe('Logger compatibility shim', () => {
+    it('exposes the same LogLevel member names and numeric values as the original enum', () => {
+        expect(LogLevel.off).to.equal(0);
+        expect(LogLevel.error).to.equal(1);
+        expect(LogLevel.warn).to.equal(2);
+        expect(LogLevel.log).to.equal(3);
+        expect(LogLevel.info).to.equal(4);
+        expect(LogLevel.debug).to.equal(5);
+        expect(LogLevel.trace).to.equal(6);
+    });
+
+    it('LogLevel remains assignable to RokuDeployOptions logLevel (the old consumer pattern)', () => {
+        //compile-time assertion: this is how consumers (e.g. brighterscript) pass the value
+        const options: RokuDeployOptions = {
+            logLevel: LogLevel.log
+        };
+        expect(options.logLevel).to.equal(LogLevel.log);
+    });
+
+    it('exposes a constructible Logger', () => {
+        const logger = new Logger();
+        expect(logger).to.be.ok;
+    });
+
+    it('noop does nothing', () => {
+        expect(noop()).to.be.undefined;
+    });
+});

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,0 +1,27 @@
+/**
+ * Backwards-compatibility shim.
+ *
+ * roku-deploy 3.18.0 migrated its logging to `@rokucommunity/logger` and deleted this module, which broke
+ * consumers that deep-import `roku-deploy/dist/Logger` (most notably brighterscript's `ProgramBuilder`).
+ * This module restores that import path by re-exporting the equivalents from `@rokucommunity/logger`:
+ *
+ * - `LogLevel` here is `@rokucommunity/logger`'s `LogLevelNumeric`, which has the exact same member names
+ *   and numeric values (off=0 through trace=6) as the enum that used to live in this file. Because it is
+ *   the same declaration used by `RokuDeployOptions['logLevel']`, values of this type remain assignable
+ *   everywhere the old enum was accepted.
+ * - `Logger` is `@rokucommunity/logger`'s `Logger` class, which carries the same core surface the old
+ *   class had (`logLevel` get/set, `error`/`warn`/`log`/`info`/`debug`/`trace`, and `time`).
+ *
+ * @deprecated import from '@rokucommunity/logger' instead. This module exists only so older consumers
+ * keep compiling and will be removed in the next major version.
+ */
+
+/** @deprecated use `LogLevelNumeric` from '@rokucommunity/logger' instead */
+export { LogLevelNumeric as LogLevel } from '@rokucommunity/logger';
+
+/** @deprecated use `Logger` from '@rokucommunity/logger' instead */
+export { Logger } from '@rokucommunity/logger';
+
+/** @deprecated this helper is no longer used by roku-deploy */
+export function noop() {
+}


### PR DESCRIPTION
## Problem

The `@rokucommunity/logger` migration (#318, released in 3.18.0) deleted `src/Logger.ts`. Consumers that deep-import `roku-deploy/dist/Logger` no longer compile against roku-deploy >= 3.18 — most notably brighterscript's `ProgramBuilder`, which imports the `LogLevel` type from there and currently breaks every create-vsix build in the org (first seen on rokucommunity/roku-debug#323).

## Fix

Restore `src/Logger.ts` as a deprecated compatibility shim that re-exports the equivalents from `@rokucommunity/logger`:

- `LogLevel` = logger's `LogLevelNumeric`, which has the exact member names and numeric values (`off=0` through `trace=6`) of the deleted enum. Because it is the same declaration `RokuDeployOptions['logLevel']` uses, the old consumer cast pattern (`as unknown as RokuDeployLogLevel`) typechecks again.
- `Logger` = logger's `Logger` class (same core surface: `logLevel` get/set, level methods, `time`).
- `noop` = local no-op, as before.

Everything carries `@deprecated` tags pointing at `@rokucommunity/logger`, to be removed in the next major version.

Verified end to end: an unmodified brighterscript master (still using the `roku-deploy/dist/Logger` deep import) compiles clean against the packed result of this branch. New unit tests pin the member values, the `RokuDeployOptions` assignability, and the module surface.