### PR TITLE
Expose public defaults and output path resolvers

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -845,6 +845,94 @@ describe('RokuDeploy', () => {
         });
     });
 
+    describe('defaults', () => {
+        it('exposes the common default values', () => {
+            expect(RokuDeploy.defaults.outDir).to.equal('./out');
+            expect(RokuDeploy.defaults.outFile).to.equal('roku-deploy.zip');
+            expect(RokuDeploy.defaults.stagingDirName).to.equal('.roku-deploy-staging');
+            expect(RokuDeploy.defaults.username).to.equal('rokudev');
+            expect(RokuDeploy.defaults.files).to.include('manifest');
+        });
+    });
+
+    describe('getStagingDir', () => {
+        it('uses out when provided', () => {
+            expect(
+                rokuDeploy.getStagingDir({ out: `${outDir}/custom-staging` })
+            ).to.equal(s`${outDir}/custom-staging`);
+        });
+
+        it('composes outDir with the default staging dir name', () => {
+            expect(
+                rokuDeploy.getStagingDir({ outDir: outDir })
+            ).to.equal(s`${outDir}/.roku-deploy-staging`);
+        });
+
+        it('falls back to all defaults when no options are provided', () => {
+            expect(
+                rokuDeploy.getStagingDir()
+            ).to.equal(s`${process.cwd()}/out/.roku-deploy-staging`);
+        });
+
+        it('resolves relative paths against cwd', () => {
+            expect(
+                rokuDeploy.getStagingDir({ outDir: 'output', cwd: tempDir })
+            ).to.equal(s`${tempDir}/output/.roku-deploy-staging`);
+        });
+    });
+
+    describe('getOutputZipPath', () => {
+        it('uses out when provided', () => {
+            expect(
+                rokuDeploy.getOutputZipPath({ out: `${outDir}/app.zip` })
+            ).to.equal(s`${outDir}/app.zip`);
+        });
+
+        it('composes outDir and outFile', () => {
+            expect(
+                rokuDeploy.getOutputZipPath({ outDir: outDir, outFile: 'app.zip' })
+            ).to.equal(s`${outDir}/app.zip`);
+        });
+
+        it('appends the zip extension when missing', () => {
+            expect(
+                rokuDeploy.getOutputZipPath({ outDir: outDir, outFile: 'app' })
+            ).to.equal(s`${outDir}/app.zip`);
+        });
+
+        it('falls back to all defaults when no options are provided', () => {
+            expect(
+                rokuDeploy.getOutputZipPath()
+            ).to.equal(s`${process.cwd()}/out/roku-deploy.zip`);
+        });
+    });
+
+    describe('getOutputPkgPath', () => {
+        it('uses out when provided', () => {
+            expect(
+                rokuDeploy.getOutputPkgPath({ out: `${outDir}/app.pkg` })
+            ).to.equal(s`${outDir}/app.pkg`);
+        });
+
+        it('swaps a zip extension for pkg', () => {
+            expect(
+                rokuDeploy.getOutputPkgPath({ outDir: outDir, outFile: 'app.zip' })
+            ).to.equal(s`${outDir}/app.pkg`);
+        });
+
+        it('appends the pkg extension when missing', () => {
+            expect(
+                rokuDeploy.getOutputPkgPath({ outDir: outDir, outFile: 'app' })
+            ).to.equal(s`${outDir}/app.pkg`);
+        });
+
+        it('falls back to all defaults when no options are provided', () => {
+            expect(
+                rokuDeploy.getOutputPkgPath()
+            ).to.equal(s`${process.cwd()}/out/roku-deploy.pkg`);
+        });
+    });
+
     describe('zip', () => {
         it('should throw error when manifest is missing', async () => {
             let err;

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -30,16 +30,35 @@ import * as semver from 'semver';
 import { fetchWithDigest } from './fetch';
 import { formatTimestampForScreenshot } from './dateUtils';
 
+export const DefaultFiles = [
+    'source/**/*.*',
+    'components/**/*.*',
+    'images/**/*.*',
+    'locale/**/*',
+    'fonts/**/*',
+    'manifest',
+    '!node_modules',
+    '!**/*.{md,DS_Store,db}'
+];
+
 export class RokuDeploy {
     /**
-     * Default values for common options used across multiple functions
+     * Default values for common options used across multiple functions.
+     * Public so consumers can resolve the same defaults roku-deploy uses internally
+     * instead of hardcoding them (see also `getStagingDir`, `getOutputZipPath` and `getOutputPkgPath`).
      */
-    private static readonly defaults = {
+    public static readonly defaults = {
         timeout: 150000,
         packagePort: 80,
         ecpPort: 8060,
+        username: 'rokudev',
         outDir: './out',
-        outFile: 'roku-deploy.zip'
+        outFile: 'roku-deploy.zip',
+        /**
+         * The name of the staging folder that gets created inside `outDir`
+         */
+        stagingDirName: '.roku-deploy-staging',
+        files: DefaultFiles
     };
 
     /**
@@ -104,6 +123,53 @@ export class RokuDeploy {
      * Copies all of the referenced files to the staging folder
      * @param options
      */
+    /**
+     * Resolve the path to the staging folder the same way `stage` does: `out` wins when provided,
+     * otherwise the default staging folder inside `outDir`.
+     */
+    public getStagingDir(options?: GetStagingDirOptions): string {
+        const cwd = options?.cwd ?? process.cwd();
+        return options?.out
+            ? path.resolve(cwd, options.out)
+            : path.resolve(cwd, options?.outDir ?? RokuDeploy.defaults.outDir, RokuDeploy.defaults.stagingDirName);
+    }
+
+    /**
+     * Resolve the path to the output zip file the same way `zip` does: `out` wins when provided,
+     * otherwise `outFile` inside `outDir`. Always ends with `.zip`.
+     */
+    public getOutputZipPath(options?: GetOutputPathOptions): string {
+        const cwd = options?.cwd ?? process.cwd();
+        let out = options?.out
+            ? path.resolve(cwd, options.out)
+            : path.resolve(cwd, options?.outDir ?? RokuDeploy.defaults.outDir, options?.outFile ?? RokuDeploy.defaults.outFile);
+
+        // Ensure .zip extension
+        if (!out.toLowerCase().endsWith('.zip')) {
+            out += '.zip';
+        }
+        return out;
+    }
+
+    /**
+     * Resolve the path to the output pkg file the same way `createSignedPackage` does: `out` wins when
+     * provided, otherwise `outFile` inside `outDir`. Always ends with `.pkg` (a `.zip` extension is swapped).
+     */
+    public getOutputPkgPath(options?: GetOutputPathOptions): string {
+        const cwd = options?.cwd ?? process.cwd();
+        let out = options?.out
+            ? path.resolve(cwd, options.out)
+            : path.resolve(cwd, options?.outDir ?? RokuDeploy.defaults.outDir, options?.outFile ?? RokuDeploy.defaults.outFile);
+
+        // Ensure .pkg extension
+        if (out.toLowerCase().endsWith('.zip')) {
+            out = out.replace(/\.zip$/i, '.pkg');
+        } else if (!out.toLowerCase().endsWith('.pkg')) {
+            out += '.pkg';
+        }
+        return out;
+    }
+
     public async stage(options: StageOptions): Promise<StageResult> {
         options = { ...this.options, ...options };
         this.logger.info('Beginning to copy files to staging folder');
@@ -114,9 +180,7 @@ export class RokuDeploy {
         const files = options.files ?? [...DefaultFiles];
 
         // Resolve output directory - use 'out' if provided, otherwise default to staging dir
-        const out = options.out
-            ? path.resolve(cwd, options.out)
-            : path.resolve(cwd, RokuDeploy.defaults.outDir, '.roku-deploy-staging');
+        const out = this.getStagingDir({ out: options.out, cwd: cwd });
 
         //clean the staging directory
         await fsExtra.remove(out);
@@ -166,14 +230,7 @@ export class RokuDeploy {
         const dir = path.resolve(cwd, options.dir);
 
         // Resolve output zip path - use 'out' if provided, otherwise default
-        let out = options.out
-            ? path.resolve(cwd, options.out)
-            : path.resolve(cwd, RokuDeploy.defaults.outDir, RokuDeploy.defaults.outFile);
-
-        // Ensure .zip extension
-        if (!out.toLowerCase().endsWith('.zip')) {
-            out += '.zip';
-        }
+        const out = this.getOutputZipPath({ out: options.out, cwd: cwd });
 
         // Get files to include - use provided files array or default to everything
         const files = options.files ?? ['**/*'];
@@ -279,7 +336,7 @@ export class RokuDeploy {
         // Set defaults for request options
         const packagePort = mergedOptions.packagePort ?? RokuDeploy.defaults.packagePort;
         const timeout = mergedOptions.timeout ?? RokuDeploy.defaults.timeout;
-        const username = mergedOptions.username ?? 'rokudev';
+        const username = mergedOptions.username ?? RokuDeploy.defaults.username;
 
         let url = `http://${mergedOptions.host}:${packagePort}/${requestPath}`;
         let baseRequestOptions = {
@@ -395,7 +452,7 @@ export class RokuDeploy {
             zipFilePath = path.resolve(cwd, options.zip);
         } else if ('dir' in options && options.dir) {
             // Generate zip from directory to a temp location
-            zipFilePath = path.resolve(cwd, RokuDeploy.defaults.outDir, RokuDeploy.defaults.outFile);
+            zipFilePath = this.getOutputZipPath({ cwd: cwd });
             await this.zip({ dir: path.resolve(cwd, options.dir), out: zipFilePath, cwd: cwd });
             deleteZipAfterSideload = true;
         } else {
@@ -706,16 +763,7 @@ export class RokuDeploy {
         const cwd = options.cwd ?? process.cwd();
 
         // Resolve output pkg path - use 'out' if provided, otherwise derive from default
-        let out = options.out
-            ? path.resolve(cwd, options.out)
-            : path.resolve(cwd, RokuDeploy.defaults.outDir, 'roku-deploy.pkg');
-
-        // Ensure .pkg extension
-        if (out.toLowerCase().endsWith('.zip')) {
-            out = out.replace(/\.zip$/i, '.pkg');
-        } else if (!out.toLowerCase().endsWith('.pkg')) {
-            out += '.pkg';
-        }
+        const out = this.getOutputPkgPath({ out: options.out, cwd: cwd });
 
         // Process options for app title and app version
         if (options.appTitle || options.appVersion) {
@@ -1286,7 +1334,7 @@ export class RokuDeploy {
      */
     public async validateDeveloperPassword(options: ValidateDeveloperPasswordOptions): Promise<boolean> {
         options = { ...this.options, ...options } as ValidateDeveloperPasswordOptions;
-        const username = options.username ?? 'rokudev';
+        const username = options.username ?? RokuDeploy.defaults.username;
         const port = options.port ?? 80;
         const timeout = options.timeout ?? 3000;
         const url = `http://${options.host}:${port}/plugin_install`;
@@ -1601,17 +1649,6 @@ enum RokuMessageType {
     error = 'error'
 }
 
-export const DefaultFiles = [
-    'source/**/*.*',
-    'components/**/*.*',
-    'images/**/*.*',
-    'locale/**/*',
-    'fonts/**/*',
-    'manifest',
-    '!node_modules',
-    '!**/*.{md,DS_Store,db}'
-];
-
 export interface HttpResponse {
     response: any;
     body: any;
@@ -1781,7 +1818,10 @@ export type ConvertToSquashfsOptions = BaseRequestOptions;
 export interface RekeyDeviceOptions extends BaseRequestOptions {
     pkg: string;
     signingPassword: string;
-    devId: string;
+    /**
+     * If specified, rekeying will fail if the resulting devId is different than this value
+     */
+    devId?: string;
     cwd?: string;
 }
 
@@ -1807,8 +1847,37 @@ export type RebootDeviceOptions = BaseRequestOptions;
 
 export type CheckForUpdateOptions = BaseRequestOptions;
 
-export interface GetOutputZipFilePathOptions {
+export interface GetStagingDirOptions {
+    /**
+     * The staging folder path. When provided, this wins over `outDir`.
+     */
     out?: string;
+    /**
+     * The output directory that contains the default staging folder. Defaults to `'./out'`.
+     */
+    outDir?: string;
+    /**
+     * The current working directory to use for relative paths
+     */
+    cwd?: string;
+}
+
+export interface GetOutputPathOptions {
+    /**
+     * The output file path. When provided, this wins over `outDir`/`outFile`.
+     */
+    out?: string;
+    /**
+     * The output directory. Defaults to `'./out'`.
+     */
+    outDir?: string;
+    /**
+     * The output file name. Defaults to `'roku-deploy.zip'`.
+     */
+    outFile?: string;
+    /**
+     * The current working directory to use for relative paths
+     */
     cwd?: string;
 }
 

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -119,57 +119,6 @@ export class RokuDeploy {
         this.logger = this.options.logger ?? logger;
     }
 
-    /**
-     * Copies all of the referenced files to the staging folder
-     * @param options
-     */
-    /**
-     * Resolve the path to the staging folder the same way `stage` does: `out` wins when provided,
-     * otherwise the default staging folder inside `outDir`.
-     */
-    public getStagingDir(options?: GetStagingDirOptions): string {
-        const cwd = options?.cwd ?? process.cwd();
-        return options?.out
-            ? path.resolve(cwd, options.out)
-            : path.resolve(cwd, options?.outDir ?? RokuDeploy.defaults.outDir, RokuDeploy.defaults.stagingDirName);
-    }
-
-    /**
-     * Resolve the path to the output zip file the same way `zip` does: `out` wins when provided,
-     * otherwise `outFile` inside `outDir`. Always ends with `.zip`.
-     */
-    public getOutputZipPath(options?: GetOutputPathOptions): string {
-        const cwd = options?.cwd ?? process.cwd();
-        let out = options?.out
-            ? path.resolve(cwd, options.out)
-            : path.resolve(cwd, options?.outDir ?? RokuDeploy.defaults.outDir, options?.outFile ?? RokuDeploy.defaults.outFile);
-
-        // Ensure .zip extension
-        if (!out.toLowerCase().endsWith('.zip')) {
-            out += '.zip';
-        }
-        return out;
-    }
-
-    /**
-     * Resolve the path to the output pkg file the same way `createSignedPackage` does: `out` wins when
-     * provided, otherwise `outFile` inside `outDir`. Always ends with `.pkg` (a `.zip` extension is swapped).
-     */
-    public getOutputPkgPath(options?: GetOutputPathOptions): string {
-        const cwd = options?.cwd ?? process.cwd();
-        let out = options?.out
-            ? path.resolve(cwd, options.out)
-            : path.resolve(cwd, options?.outDir ?? RokuDeploy.defaults.outDir, options?.outFile ?? RokuDeploy.defaults.outFile);
-
-        // Ensure .pkg extension
-        if (out.toLowerCase().endsWith('.zip')) {
-            out = out.replace(/\.zip$/i, '.pkg');
-        } else if (!out.toLowerCase().endsWith('.pkg')) {
-            out += '.pkg';
-        }
-        return out;
-    }
-
     public async stage(options: StageOptions): Promise<StageResult> {
         options = { ...this.options, ...options };
         this.logger.info('Beginning to copy files to staging folder');


### PR DESCRIPTION
With `getOptions()` gone in v4, consumers (roku-debug and the vscode extension, currently being migrated) have no way to resolve the defaults roku-deploy uses internally, so they end up hardcoding `.roku-deploy-staging` and `roku-deploy.zip` strings.

- Make `RokuDeploy.defaults` public and add `stagingDirName`, `username`, and `files` (the existing `DefaultFiles`)
- Add `getStagingDir`, `getOutputZipPath`, and `getOutputPkgPath` resolvers (`{out?, outDir?, outFile?, cwd?}`, where `out` wins; zip/pkg extension enforcement included). `stage`, `zip`, `sideload`, and `createSignedPackage` now resolve their paths through these same functions, so the library and its consumers can't drift
- Make `RekeyDeviceOptions.devId` optional: `rekeyDevice` only uses it as a post-rekey verification and `checkRequiredOptions` doesn't include it
- Replace the unused `GetOutputZipFilePathOptions` interface with the new resolver option interfaces