### PR TITLE
chore: Simplify create-vsix inputs and improve branch resolution

### DIFF
--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -27,8 +27,18 @@ jobs:
           private_key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Set New GitHub Token
         run: echo "TOKEN=${{ steps.generate-token.outputs.token }}" >> $GITHUB_ENV
-      # Trigger the build on vscode-brightscript-language. That workflow interprets these
-      # inputs, builds the .vsix files, and posts the download links back on the PR
+      # Resolve the input to a full PR URL (a bare PR number refers to this repo)
+      - name: Resolve PR URL
+        id: pr
+        run: |
+          input="${{ github.event.pull_request.html_url || github.event.inputs.pr }}"
+          if [[ "$input" =~ ^[0-9]+$ ]]; then
+            input="https://github.com/${{ github.repository }}/pull/$input"
+          fi
+          echo "url=$input" >> "$GITHUB_OUTPUT"
+      # Trigger the build on vscode-brightscript-language. That workflow looks up the PR, builds the
+      # .vsix files (preferring same-named branches attached to open PRs across all the projects),
+      # and posts the download links back on the PR
       - name: Build vsix
         uses: aurelien-baudet/workflow-dispatch@v2.1.1
         id: create-vsix
@@ -39,4 +49,4 @@ jobs:
           display-workflow-run-url: true
           repo: rokucommunity/vscode-brightscript-language
           token: ${{ env.TOKEN }}
-          inputs: '{ "branch": "${{ github.head_ref }}", "pr": "${{ github.event.pull_request.html_url || github.event.inputs.pr }}", "repo": "${{ github.repository }}" }'
+          inputs: '{ "pr": "${{ steps.pr.outputs.url }}" }'


### PR DESCRIPTION
## What
Passes a single `pr` URL to the [vscode-brightscript-language create-vsix workflow](https://github.com/rokucommunity/vscode-brightscript-language/actions/workflows/create-vsix.yml) instead of the separate `branch`/`pr`/`repo` inputs. A bare PR number dispatch input is resolved to this repo's PR URL first.

## Why
That workflow now looks up the PR itself and resolves each project's build source with this priority (see rokucommunity/vscode-brightscript-language#867):
1. rokucommunity branch attached to an open PR
2. the originating fork owner's same-named branch attached to an open PR
3. rokucommunity branch without a PR
4. master

## Rollout
⚠️ Must merge together with rokucommunity/vscode-brightscript-language#867 — `workflow_dispatch` rejects unknown inputs, so the old `branch`/`repo` payload fails once that PR merges (and this new payload fails until it does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
