### PR TITLE
Fix mocha/ts-node breaking on Node 22+

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,0 +1,13 @@
+const nodeVersion = +process.versions.node.split('.')[0];
+const config = {
+    require: [
+        'source-map-support/register',
+        'ts-node/register'
+    ],
+    fullTrace: true,
+    watchExtensions: ['ts']
+};
+if (nodeVersion >= 22) {
+    config['node-option'] = ['no-experimental-strip-types'];
+}
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -70,16 +70,6 @@
             "uuid": "^11.1.1"
         }
     },
-    "mocha": {
-        "require": [
-            "source-map-support/register",
-            "ts-node/register"
-        ],
-        "fullTrace": true,
-        "watchExtensions": [
-            "ts"
-        ]
-    },
     "typings": "dist/index.d.ts",
     "bin": {
         "roku-deploy": "dist/cli.js"


### PR DESCRIPTION
## Summary
- Node 22 introduced a built-in TypeScript type-stripping loader that intercepts `.ts` files before `ts-node/register` (registered via mocha's `require`) gets a chance to handle them.
- That native stripper rejects legacy angle-bracket type assertions (`<any>rokuDeploy`) used throughout the spec files, since the syntax is ambiguous with JSX, causing `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX` on `npm test`/`npm run test:nocover`.
- Moved the `mocha` config out of `package.json` into `.mocharc.cjs`, which conditionally disables the native stripper via `--no-experimental-strip-types` when running on Node >= 22 — same approach already applied in brighterscript.
- No change in behavior on Node < 22; no dev workflow changes required.

Coverage thresholds are currently failing due to a pre-existing coverage gap unrelated to this fix (`check-coverage` already set to `false`, to be revisited separately).

## Test plan
- [x] `npm run test:nocover` passes on Node 22 (590 passing)
- [x] `npm test` runs without the TS syntax crash on Node 22 (coverage gap unrelated, tracked separately)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)