### PR TITLE
Fix mocha/ts-node breaking on Node 22+

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,0 +1,13 @@
+const nodeVersion = +process.versions.node.split('.')[0];
+const config = {
+    require: [
+        'source-map-support/register',
+        'ts-node/register'
+    ],
+    fullTrace: true,
+    watchExtensions: ['ts']
+};
+if (nodeVersion >= 22) {
+    config['node-option'] = ['no-experimental-strip-types'];
+}
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -61,16 +61,6 @@
     "overrides": {
         "serialize-javascript": "^7.0.5"
     },
-    "mocha": {
-        "require": [
-            "source-map-support/register",
-            "ts-node/register"
-        ],
-        "fullTrace": true,
-        "watchExtensions": [
-            "ts"
-        ]
-    },
     "typings": "dist/index.d.ts",
     "bin": {
         "roku-deploy": "dist/cli.js"


### PR DESCRIPTION
## Summary
- Node 22 introduced a built-in TypeScript type-stripping loader that intercepts `.ts` files before `ts-node/register` (registered via mocha's `require`) gets a chance to handle them.
- That native stripper rejects legacy angle-bracket type assertions (`<any>rokuDeploy`) used throughout the spec files, since the syntax is ambiguous with JSX, causing `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX` under Node 22.
- Moved the `mocha` config out of `package.json` into `.mocharc.cjs`, which conditionally disables the native stripper via `--no-experimental-strip-types` when running on Node >= 22 — same fix already applied in brighterscript and roku-deploy v4 (#341).
- No change in behavior on Node < 22; no dev workflow changes required.

Note: there's a pre-existing, unrelated test failure/TS error on this branch (JSZip `Compression` type overload mismatch during a `npm run build` invoked from a spec) — not touched by this PR.

## Test plan
- [x] `npm run test:nocover` runs without the TS syntax crash on Node 22
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)