### PR TITLE
Close code coverage gaps to hit 100%

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         ],
         "sourceMap": true,
         "instrument": true,
-        "check-coverage": false,
+        "check-coverage": true,
         "lines": 100,
         "statements": 100,
         "functions": 100,

--- a/src/DeviceConfig.spec.ts
+++ b/src/DeviceConfig.spec.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import { isLocalDeviceConfig, isRceDeviceConfig, isRceByEsn, isRceById, isRceByUrl } from './DeviceConfig';
+
+describe('DeviceConfig', () => {
+    describe('isLocalDeviceConfig', () => {
+        it('returns true for a local device config', () => {
+            expect(isLocalDeviceConfig({ host: '1.2.3.4' })).to.be.true;
+        });
+
+        it('returns false for an RCE device config', () => {
+            expect(isLocalDeviceConfig({ esn: 'ABC123' } as any)).to.be.false;
+        });
+    });
+
+    describe('isRceDeviceConfig', () => {
+        it('returns true for an esn-based RCE device config', () => {
+            expect(isRceDeviceConfig({ esn: 'ABC123' } as any)).to.be.true;
+        });
+
+        it('returns true for an id-based RCE device config', () => {
+            expect(isRceDeviceConfig({ id: 'device-1' } as any)).to.be.true;
+        });
+
+        it('returns true for an instanceUrl-based RCE device config', () => {
+            expect(isRceDeviceConfig({ instanceUrl: 'https://example.com' } as any)).to.be.true;
+        });
+
+        it('returns false for a local device config', () => {
+            expect(isRceDeviceConfig({ host: '1.2.3.4' })).to.be.false;
+        });
+    });
+
+    describe('isRceByEsn', () => {
+        it('returns true when config has an esn', () => {
+            expect(isRceByEsn({ esn: 'ABC123' })).to.be.true;
+        });
+
+        it('returns false when config does not have an esn', () => {
+            expect(isRceByEsn({ id: 'device-1' } as any)).to.be.false;
+        });
+    });
+
+    describe('isRceById', () => {
+        it('returns true when config has an id', () => {
+            expect(isRceById({ id: 'device-1' })).to.be.true;
+        });
+
+        it('returns false when config does not have an id', () => {
+            expect(isRceById({ esn: 'ABC123' } as any)).to.be.false;
+        });
+    });
+
+    describe('isRceByUrl', () => {
+        it('returns true when config has an instanceUrl', () => {
+            expect(isRceByUrl({ instanceUrl: 'https://example.com' })).to.be.true;
+        });
+
+        it('returns false when config does not have an instanceUrl', () => {
+            expect(isRceByUrl({ esn: 'ABC123' } as any)).to.be.false;
+        });
+    });
+});

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -5249,6 +5249,125 @@ describe('RokuDeploy', () => {
         });
     });
 
+    describe('resolveDevice', () => {
+        it('resolves a device from the devices registry by host', async () => {
+            const rd = new RokuDeploy({
+                devices: {
+                    'living-room': { host: '1.2.3.4' }
+                }
+            });
+            sinon.stub(rd as any, 'doGetRequest').callsFake((params) => {
+                let results = { response: { statusCode: 200 }, body: '<device-info></device-info>' };
+                rd['checkRequest'](results);
+                return Promise.resolve(results);
+            });
+            const deviceInfo = await rd.getDeviceInfo({
+                device: 'living-room'
+            });
+            expect(deviceInfo).not.to.be.undefined;
+        });
+
+        it('resolves a device from the devices registry by esn', async () => {
+            const rd = new RokuDeploy({
+                devices: {
+                    'cloud-device': { esn: 'ABC123' }
+                }
+            });
+            let ex;
+            try {
+                await rd.getDeviceInfo({
+                    device: 'cloud-device'
+                });
+            } catch (e) {
+                ex = e;
+            }
+            expect(ex?.message).to.eql('RCE devices are not yet supported');
+        });
+
+        it('resolves a device from the devices registry by id', async () => {
+            const rd = new RokuDeploy({
+                devices: {
+                    'cloud-device': { id: 'device-id-1' }
+                }
+            });
+            let ex;
+            try {
+                await rd.getDeviceInfo({
+                    device: 'cloud-device'
+                });
+            } catch (e) {
+                ex = e;
+            }
+            expect(ex?.message).to.eql('RCE devices are not yet supported');
+        });
+
+        it('resolves a device from the devices registry by instanceUrl', async () => {
+            const rd = new RokuDeploy({
+                devices: {
+                    'cloud-device': { instanceUrl: 'https://example.com' }
+                }
+            });
+            let ex;
+            try {
+                await rd.getDeviceInfo({
+                    device: 'cloud-device'
+                });
+            } catch (e) {
+                ex = e;
+            }
+            expect(ex?.message).to.eql('RCE devices are not yet supported');
+        });
+
+        it('throws when a registry entry has no valid identifier', async () => {
+            const rd = new RokuDeploy({
+                devices: {
+                    'bogus-device': {}
+                }
+            });
+            await expectThrowsAsync(async () => {
+                await rd.getDeviceInfo({
+                    device: 'bogus-device'
+                });
+            }, 'Device registry entry has no valid identifier (host, esn, id, or instanceUrl)');
+        });
+
+        it('throws when the device name is not found in the registry', async () => {
+            const rd = new RokuDeploy({
+                devices: {}
+            });
+            await expectThrowsAsync(async () => {
+                await rd.getDeviceInfo({
+                    device: 'does-not-exist'
+                });
+            }, `Device 'does-not-exist' not found in devices registry`);
+        });
+
+        it('throws when the device name is used but no devices registry was configured', async () => {
+            const rd = new RokuDeploy();
+            await expectThrowsAsync(async () => {
+                await rd.getDeviceInfo({
+                    device: 'does-not-exist'
+                });
+            }, `Device 'does-not-exist' not found in devices registry`);
+        });
+
+        it('throws when an inline device config has no identifier', async () => {
+            await expectThrowsAsync(async () => {
+                await rokuDeploy.getDeviceInfo({
+                    device: {} as any
+                });
+            }, 'Device must specify host, esn, id, or instanceUrl');
+        });
+
+        it('throws when an inline device config has multiple identifiers', async () => {
+            await expectThrowsAsync(async () => {
+                await rokuDeploy.getDeviceInfo({
+                    device: { host: '1.2.3.4', esn: 'ABC123' } as any
+                });
+            }, 'Device cannot specify multiple identifiers (host, esn, id, instanceUrl)');
+        });
+    });
+
     describe('option validation', () => {
         beforeEach(() => {
             //make a dummy output file for tests that need a valid zip

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -103,6 +103,27 @@ describe('cli', function cli() {
         });
     });
 
+    it('Rekeys a device using the provided cwd', async () => {
+        const stub = sinon.stub(rokuDeploy, 'rekeyDevice').callsFake(async () => {
+            return Promise.resolve();
+        });
+
+        const command = new RekeyDeviceCommand();
+        await command.run({
+            cwd: cwd,
+            host: '1.2.3.4',
+            password: '5536'
+        });
+
+        expect(
+            stub.getCall(0).args[0]
+        ).to.eql({
+            cwd: cwd,
+            host: '1.2.3.4',
+            password: '5536'
+        });
+    });
+
     it('Signs an existing package', async () => {
         const stub = sinon.stub(rokuDeploy, 'createSignedPackage').callsFake(async () => {
             return Promise.resolve({ pkgPath: '' });
@@ -124,6 +145,27 @@ describe('cli', function cli() {
             password: '5536',
             signingPassword: undefined,
             stagingDir: stagingDir
+        });
+    });
+
+    it('Signs an existing package using the provided cwd', async () => {
+        const stub = sinon.stub(rokuDeploy, 'createSignedPackage').callsFake(async () => {
+            return Promise.resolve({ pkgPath: '' });
+        });
+
+        const command = new CreateSignedPackageCommand();
+        await command.run({
+            cwd: cwd,
+            host: '1.2.3.4',
+            password: '5536'
+        });
+
+        expect(
+            stub.getCall(0).args[0]
+        ).to.eql({
+            cwd: cwd,
+            host: '1.2.3.4',
+            password: '5536'
         });
     });
 
@@ -153,6 +195,27 @@ describe('cli', function cli() {
 
         const command = new CaptureScreenshotCommand();
         await command.run({
+            host: '1.2.3.4',
+            password: '5536'
+        });
+
+        expect(
+            stub.getCall(0).args[0]
+        ).to.eql({
+            cwd: cwd,
+            host: '1.2.3.4',
+            password: '5536'
+        });
+    });
+
+    it('Takes a screenshot using the provided cwd', async () => {
+        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').callsFake(async () => {
+            return Promise.resolve({ buffer: Buffer.from(''), filePath: '' });
+        });
+
+        const command = new CaptureScreenshotCommand();
+        await command.run({
+            cwd: cwd,
             host: '1.2.3.4',
             password: '5536'
         });


### PR DESCRIPTION
## Summary
- Adds tests for the untested device-registry resolution logic in `RokuDeploy.ts` (`resolveDevice`, `validateDeviceConfig`, `extractDeviceConfig`, `getHost`)
- Adds a new `DeviceConfig.spec.ts` covering the type guards (`isLocalDeviceConfig`, `isRceDeviceConfig`, `isRceByEsn`, `isRceById`, `isRceByUrl`)
- Adds CLI tests covering the `cwd`-already-set branch for `RekeyDeviceCommand`, `CreateSignedPackageCommand`, and `CaptureScreenshotCommand`
- Re-enables the `check-coverage` nyc gate now that coverage is at 100% across statements/branches/functions/lines

## Test plan
- [x] `npm run test` passes with 100% coverage on all four metrics
- [x] `npm run build` succeeds
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)