### PR TITLE
Fix getDestPath dropping absolute src entries

### DIFF
--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -651,7 +651,7 @@ describe('util', () => {
                     }],
                     rootDir
                 )
-            ).to.equal('source/standalone.brs');
+            ).to.equal(s`source/standalone.brs`);
         });
     });
 

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -640,6 +640,19 @@ describe('util', () => {
                 )
             ).to.be.undefined;
         });
+
+        it('finds dest path for an absolute src entry outside the root dir', () => {
+            expect(
+                util.getDestPath(
+                    s`${rootDir}/../externalDir/main.brs`,
+                    [{
+                        src: s`${rootDir}/../externalDir/main.brs`,
+                        dest: 'source/standalone.brs'
+                    }],
+                    rootDir
+                )
+            ).to.equal('source/standalone.brs');
+        });
     });
 
     describe('computeFileDestPath', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -364,14 +364,8 @@ export class Util {
         const entries = util.normalizeFilesArray(files);
 
         function makeGlobAbsolute(pattern: string) {
-            return path.resolve(
-                path.posix.join(
-                    rootDir,
-                    //remove leading exclamation point if pattern is negated
-                    pattern
-                    //coerce all slashes to forward
-                )
-            ).replace(/\\/g, '/');
+            //resolve the pattern relative to rootDir (absolute patterns stand on their own), and coerce all slashes to forward
+            return path.resolve(rootDir, pattern).replace(/\\/g, '/');
         }
 
         let result: string;


### PR DESCRIPTION
When the v4 reorg moved `getDestPath` into `util.ts`, its `makeGlobAbsolute` helper changed from `path.resolve(rootDir, pattern)` to `path.resolve(path.posix.join(rootDir, pattern))`. `path.posix.join` concatenates rather than resolves, so an absolute `src` entry gets appended onto `rootDir` and never matches the file it names, making `getDestPath` return `undefined`.

This breaks consumers that pass absolute `src` entries, most notably brighterscript's LSP standalone projects, which register a single open file as `{ src: <absolute path>, dest: 'source/standalone.brs' }` under a synthetic rootDir.

This restores the resolve semantics (absolute patterns stand on their own, relative patterns resolve against rootDir) and adds a regression test.