### PR TITLE
Move constructor to the top of all classes (#338)

### DIFF
--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -103,6 +103,15 @@ export interface UnsupportedFirmwareDetails {
  * Provides consistent error handling with typed details and serialization support.
  */
 export abstract class RokuDeployError<T = unknown> extends Error {
+    constructor(message: string, details?: T, cause?: Error) {
+        super(message);
+        this.name = this.constructor.name;
+        this.details = details ?? {} as T;
+        this.cause = cause;
+        // Restore prototype chain for proper instanceof checks
+        Object.setPrototypeOf(this, new.target.prototype);
+    }
+
     /**
      * Error code for programmatic identification
      */
@@ -117,15 +126,6 @@ export abstract class RokuDeployError<T = unknown> extends Error {
      * Original error if this error wraps another
      */
     public readonly cause?: Error;
-
-    constructor(message: string, details?: T, cause?: Error) {
-        super(message);
-        this.name = this.constructor.name;
-        this.details = details ?? {} as T;
-        this.cause = cause;
-        // Restore prototype chain for proper instanceof checks
-        Object.setPrototypeOf(this, new.target.prototype);
-    }
 
     /**
      * Serialize the error for logging/transmission
@@ -229,13 +229,13 @@ export class EcpNetworkAccessModeDisabledError extends DeviceError {
  * the user to check for updates (even if no updates are actually available).
  */
 export class UpdateCheckRequiredError extends RokuDeployError<ConnectionErrorDetails> {
-    public readonly code = RokuDeployErrorCode.UPDATE_CHECK_REQUIRED;
-
-    static MESSAGE = `Your device needs to check for updates before accepting connections. Please navigate to System Settings and check for updates and then try again.\n\nhttps://support.roku.com/article/208755668.`;
-
     constructor(details?: ConnectionErrorDetails, cause?: Error) {
         super(UpdateCheckRequiredError.MESSAGE, details, cause);
     }
+
+    public readonly code = RokuDeployErrorCode.UPDATE_CHECK_REQUIRED;
+
+    static MESSAGE = `Your device needs to check for updates before accepting connections. Please navigate to System Settings and check for updates and then try again.\n\nhttps://support.roku.com/article/208755668.`;
 }
 
 /**
@@ -244,14 +244,14 @@ export class UpdateCheckRequiredError extends RokuDeployError<ConnectionErrorDet
  * but it can also happen for other reasons.
  */
 export class ConnectionResetError extends RokuDeployError<ConnectionErrorDetails> {
-    public readonly code = RokuDeployErrorCode.CONNECTION_RESET;
-
-    static MESSAGE = `The Roku device ended the connection unexpectedly and may need to check for updates before accepting connections. Please navigate to System Settings and check for updates and then try again.\n\nhttps://support.roku.com/article/208755668.`;
-
     // eslint-disable-next-line @typescript-eslint/no-useless-constructor
     constructor(details?: ConnectionErrorDetails, cause?: Error) {
         super(ConnectionResetError.MESSAGE, details, cause);
     }
+
+    public readonly code = RokuDeployErrorCode.CONNECTION_RESET;
+
+    static MESSAGE = `The Roku device ended the connection unexpectedly and may need to check for updates before accepting connections. Please navigate to System Settings and check for updates and then try again.\n\nhttps://support.roku.com/article/208755668.`;
 }
 
 /**

--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -3322,12 +3322,12 @@ describe('RokuDeploy', () => {
         });
 
         class ErrorWithConnectionResetCode extends Error {
-            code;
-
             constructor(code = 'ECONNRESET') {
                 super();
                 this.code = code;
             }
+
+            code;
         }
 
         it('Should throw an exception', async () => {
@@ -3831,12 +3831,12 @@ describe('RokuDeploy', () => {
     });
 
     class ErrorWithCode extends Error {
-        code;
-
         constructor(code = 'HPE_INVALID_CONSTANT') {
             super();
             this.code = code;
         }
+
+        code;
     }
 
     describe('rekey', () => {


### PR DESCRIPTION
Closes #338.

Moves the `constructor` to be the first member in every class that has one, so it's consistently the first thing you see. Pure reordering — no behavior changes.

Classes updated:
- `RokuDeployError` (abstract base), `UpdateCheckRequiredError`, `ConnectionResetError` in `src/Errors.ts`
- `ErrorWithConnectionResetCode`, `ErrorWithCode` (test helpers) in `src/RokuDeploy.spec.ts`

Field/static declarations that previously sat above the constructor were moved below it. Class field initializers still run after `super()` regardless of textual position, so ordering is unaffected.

All other constructor-bearing classes already had the constructor first.

I skipped the lint-rule suggestion.