### PR TITLE
Stop returning json from sendEcpRequest

### DIFF
--- a/src/RokuDeploy.spec.ts
+++ b/src/RokuDeploy.spec.ts
@@ -817,23 +817,22 @@ describe('RokuDeploy', () => {
     });
 
     describe('sendEcpRequest', () => {
-        it('builds the LAN url from the host and ecp port, defaulting to GET, and parses the XML body', async () => {
+        it('builds the LAN url from the host and ecp port, defaulting to GET, and returns the raw body', async () => {
             const stub = mockDoGetRequest('<device-info><model-name>Roku</model-name></device-info>');
 
             const result = await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'query/device-info');
 
             expect(stub.getCall(0).args[0].url).to.equal('http://1.1.1.1:8060/query/device-info');
             expect(result.status).to.equal(200);
-            expect(result.json).to.eql({ 'device-info': { 'model-name': 'Roku' } });
+            expect(result.body).to.equal('<device-info><model-name>Roku</model-name></device-info>');
         });
 
-        it('sends POST requests with a custom ecp port and returns undefined json for an empty body', async () => {
+        it('sends POST requests with a custom ecp port', async () => {
             const stub = mockDoPostRequest();
 
-            const result = await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'keypress/Home', { method: 'POST', ecpPort: 9060 });
+            await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'keypress/Home', { method: 'POST', ecpPort: 9060 });
 
             expect(stub.getCall(0).args[0].url).to.equal('http://1.1.1.1:9060/keypress/Home');
-            expect(result.json).to.be.undefined;
         });
 
         it('routes an RCE device through the instance ecp1 proxy with the X-Authorization bearer header', async () => {
@@ -846,7 +845,7 @@ describe('RokuDeploy', () => {
 
             expect(stub.getCall(0).args[0].url).to.equal('https://device.rce.roku.com/instance/abc/ecp1/query/sgrendezvous');
             expect(stub.getCall(0).args[0].headers).to.eql({ 'X-Authorization': 'Bearer secret' });
-            expect(result.json.sgrendezvous.status).to.equal('OK');
+            expect(result.body).to.equal('<sgrendezvous><status>OK</status></sgrendezvous>');
         });
 
         it('falls back to the constructor default rceToken for an RCE device config without one', async () => {
@@ -879,7 +878,7 @@ describe('RokuDeploy', () => {
             //verification must be off by default so the raw ECP status body comes back
             expect(stub.getCall(0).args[1]).to.equal(false);
             expect(result.status).to.equal(202);
-            expect(result.json['plugin-registry'].error).to.equal('Device not keyed');
+            expect(result.body).to.include('<error>Device not keyed</error>');
         });
 
         it('passes verify through to the request layer when set', async () => {
@@ -893,7 +892,7 @@ describe('RokuDeploy', () => {
             expect(stub.getCall(0).args[1]).to.equal(true);
         });
 
-        it('returns undefined json (with the body preserved) for a non-xml response', async () => {
+        it('returns a non-xml response body as-is', async () => {
             sinon.stub(rokuDeploy as any, 'doGetRequest').resolves({
                 response: { statusCode: 404 },
                 body: 'no healthy upstream'
@@ -903,24 +902,22 @@ describe('RokuDeploy', () => {
 
             expect(result.status).to.equal(404);
             expect(result.body).to.equal('no healthy upstream');
-            expect(result.json).to.be.undefined;
         });
 
-        it('throws when a response that looks like xml cannot be parsed', async () => {
+        it('returns an unparsable xml body as-is without throwing', async () => {
             sinon.stub(rokuDeploy as any, 'doGetRequest').resolves({
                 response: { statusCode: 200 },
                 body: '<device-info><unclosed'
             });
 
-            await expectThrowsAsync(async () => {
-                await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'query/device-info');
-            }, 'Could not parse ECP response');
+            const result = await rokuDeploy.sendEcpRequest({ host: '1.1.1.1' }, 'query/device-info');
+
+            expect(result.body).to.equal('<device-info><unclosed');
         });
 
-        it('wraps a parse failure that carries no http response and a non-Error parse rejection', async () => {
-            //parseEcpXml's response argument is optional; the wrap must not blow up without it
+        it('parseEcpXml wraps a parse failure and a non-Error parse rejection', async () => {
             await expectThrowsAsync(async () => {
-                await rokuDeploy['parseEcpXml']('<device-info><unclosed');
+                await rokuDeploy['parseEcpXml']({ status: 200, body: '<device-info><unclosed' });
             }, 'Could not parse ECP response');
 
             //a non-Error rejection from the xml parser must not be attached as the cause
@@ -928,7 +925,7 @@ describe('RokuDeploy', () => {
             sinon.stub(xml2js, 'parseStringPromise').callsFake(() => Promise.reject('not an error instance'));
             let caughtError: errors.UnparsableDeviceResponseError;
             try {
-                await rokuDeploy['parseEcpXml']('<device-info></device-info>');
+                await rokuDeploy['parseEcpXml']({ status: 200, body: '<device-info></device-info>' });
             } catch (e) {
                 caughtError = e as errors.UnparsableDeviceResponseError;
             }
@@ -944,7 +941,7 @@ describe('RokuDeploy', () => {
 
             const result = await rd.sendEcpRequest({ id: 123 }, 'query/device-info');
 
-            expect(result).to.eql({ status: undefined, body: undefined, json: undefined });
+            expect(result).to.eql({ status: undefined, body: undefined });
         });
 
         it('retries against a refreshed instance url when the mesh reports the cached instance gone', async () => {
@@ -969,7 +966,7 @@ describe('RokuDeploy', () => {
             expect(stub.callCount).to.equal(2);
             expect(stub.getCall(1).args[0].url).to.equal('https://device.rce.roku.com/instance/new/ecp1/query/device-info');
             expect(result.status).to.equal(200);
-            expect(result.json['device-info']['model-name']).to.equal('Roku');
+            expect(result.body).to.equal('<device-info><model-name>Roku</model-name></device-info>');
         });
 
         it('returns a 404 answered by a live instance as-is without retrying', async () => {
@@ -2254,7 +2251,7 @@ describe('RokuDeploy', () => {
         it('tolerates a transport layer that resolved no response at all', async () => {
             sinon.stub(rokuDeploy as any, 'doPostRequest').resolves(undefined);
             const result = await rokuDeploy.keyPress({ device: rceDevice, key: 'Home' });
-            expect(result).to.eql({ status: undefined, body: undefined, json: undefined });
+            expect(result).to.eql({ status: undefined, body: undefined });
         });
 
         it('throws the ECP token-required error when an RCE device has no rceToken at all', async () => {

--- a/src/RokuDeploy.ts
+++ b/src/RokuDeploy.ts
@@ -617,7 +617,7 @@ export class RokuDeploy {
             }
             throw e;
         }
-        const deviceInfoRoot = result.json?.['device-info'];
+        const deviceInfoRoot = (await this.parseEcpXml(result))?.['device-info'];
         if (!deviceInfoRoot) {
             //the response was not device-info XML (an empty body, a proxy error page, ...) - there
             //is no underlying error to carry as a cause, the body just wasn't what we asked for
@@ -891,8 +891,8 @@ export class RokuDeploy {
     }
 
     /**
-     * Send a raw External Control Protocol (ECP) request to a device and return the response with
-     * its XML body parsed to JSON. This is the single ECP transport: every ECP convenience method
+     * Send a raw External Control Protocol (ECP) request to a device and return the raw response
+     * (status code and body). This is the single ECP transport: every ECP convenience method
      * funnels through it, and it is public so any ECP route can be reached even when no dedicated
      * wrapper exists for it yet.
      *
@@ -942,8 +942,7 @@ export class RokuDeploy {
 
         return {
             status: response?.response?.statusCode,
-            body: response?.body,
-            json: await this.parseEcpXml(response?.body, response)
+            body: response?.body
         };
     }
 
@@ -1074,7 +1073,7 @@ export class RokuDeploy {
         });
         //devices report exit-app failures through the ECP envelope (a 202 with the error in the
         //body), so surface that message; fall back to a plain status check when there is no envelope
-        const root = result.json?.['exit-app'];
+        const root = (await this.parseEcpXml(result))?.['exit-app'];
         if (root && typeof root.status === 'string' && root.status.toLowerCase() !== 'ok') {
             throw new FailedDeviceResponseError(`Could not exit app: ${root.error ?? 'Unknown error'}`, {
                 httpDetails: this.buildEcpHttpDetails(result)
@@ -1104,11 +1103,13 @@ export class RokuDeploy {
         this.checkRequiredOptions(options, ['device']);
 
         let result: EcpResult;
+        let json: Record<string, any> | undefined;
         try {
             result = await this.sendEcpRequest(options.device, 'query/apps', {
                 ecpPort: options.ecpPort,
                 timeout: options.timeout
             });
+            json = await this.parseEcpXml(result);
         } catch (e) {
             if (e instanceof UnparsableDeviceResponseError) {
                 this.logger.warn('Error parsing installed app list:', e);
@@ -1117,7 +1118,7 @@ export class RokuDeploy {
             throw e;
         }
         this.assertEcpStatusOk(result);
-        const rawAppNodes = result.json?.apps?.app;
+        const rawAppNodes = json?.apps?.app;
         if (!rawAppNodes) {
             return [];
         }
@@ -1144,11 +1145,13 @@ export class RokuDeploy {
         this.checkRequiredOptions(options, ['device']);
 
         let result: EcpResult;
+        let json: Record<string, any> | undefined;
         try {
             result = await this.sendEcpRequest(options.device, 'query/active-app', {
                 ecpPort: options.ecpPort,
                 timeout: options.timeout
             });
+            json = await this.parseEcpXml(result);
         } catch (e) {
             if (e instanceof UnparsableDeviceResponseError) {
                 this.logger.warn('Error parsing active app:', e);
@@ -1157,7 +1160,7 @@ export class RokuDeploy {
             throw e;
         }
         this.assertEcpStatusOk(result);
-        const rawActiveAppNode = result.json?.['active-app']?.app;
+        const rawActiveAppNode = json?.['active-app']?.app;
         if (!rawActiveAppNode) {
             return {};
         }
@@ -1178,7 +1181,7 @@ export class RokuDeploy {
             ecpPort: options.ecpPort,
             timeout: options.timeout
         });
-        const root = this.getEcpEnvelope(result, 'plugin-registry', 'Could not retrieve registry');
+        const root = await this.getEcpEnvelope(result, 'plugin-registry', 'Could not retrieve registry');
 
         const registry = root.registry ?? {};
         const sections: RokuRegistry['sections'] = {};
@@ -1216,7 +1219,7 @@ export class RokuDeploy {
             ecpPort: options.ecpPort,
             timeout: options.timeout
         });
-        const root = this.getEcpEnvelope(result, 'app-state', 'Could not retrieve app state');
+        const root = await this.getEcpEnvelope(result, 'app-state', 'Could not retrieve app state');
 
         const knownStates: RokuAppStateValue[] = ['active', 'background', 'inactive'];
         const state = knownStates.find(knownState => knownState === root.state?.toLowerCase()) ?? 'unknown';
@@ -1243,7 +1246,7 @@ export class RokuDeploy {
             ecpPort: options.ecpPort,
             timeout: options.timeout
         });
-        const root = this.getEcpEnvelope(result, 'sgrendezvous', 'Could not retrieve rendezvous tracking');
+        const root = await this.getEcpEnvelope(result, 'sgrendezvous', 'Could not retrieve rendezvous tracking');
 
         return {
             trackingEnabled: root.data?.['tracking-enabled'] === 'true',
@@ -1272,7 +1275,7 @@ export class RokuDeploy {
             ecpPort: options.ecpPort,
             timeout: options.timeout
         });
-        const root = this.getEcpEnvelope(result, 'sgrendezvous', 'Could not set rendezvous tracking');
+        const root = await this.getEcpEnvelope(result, 'sgrendezvous', 'Could not set rendezvous tracking');
         return root['tracking-enabled'] === 'true';
     }
 
@@ -1957,7 +1960,8 @@ export class RokuDeploy {
      * undefined so the caller can inspect the status and raw body instead; a body that looks like
      * XML but cannot be parsed throws.
      */
-    private async parseEcpXml(body: string, response?: HttpResponse): Promise<Record<string, any> | undefined> {
+    private async parseEcpXml(result: EcpResult): Promise<Record<string, any> | undefined> {
+        const body = result.body;
         if (typeof body !== 'string' || !body.trim().startsWith('<')) {
             return undefined;
         }
@@ -1969,7 +1973,7 @@ export class RokuDeploy {
             return { ...parsedContent };
         } catch (e) {
             throw new UnparsableDeviceResponseError('Could not parse ECP response', {
-                httpDetails: extractHttpDetails(response?.response, response?.body)
+                httpDetails: this.buildEcpHttpDetails(result)
             }, e instanceof Error ? e : undefined);
         }
     }
@@ -2003,8 +2007,7 @@ export class RokuDeploy {
                 });
                 return {
                     status: response?.response?.statusCode,
-                    body: response?.body,
-                    json: undefined
+                    body: response?.body
                 } as EcpResult;
             } catch (e) {
                 this.logger.warn('RCE instance-api key route failed; falling back to the ecp1 proxy', (e as Error)?.message ?? '');
@@ -2111,8 +2114,8 @@ export class RokuDeploy {
      * non-OK `<status>` - which ECP reports with a 202 rather than an error status code - and an
      * UnparsableDeviceResponseError when the expected root element is missing entirely.
      */
-    private getEcpEnvelope(result: EcpResult, rootKey: string, failureMessage: string): Record<string, any> {
-        const root = result.json?.[rootKey];
+    private async getEcpEnvelope(result: EcpResult, rootKey: string, failureMessage: string): Promise<Record<string, any>> {
+        const root = (await this.parseEcpXml(result))?.[rootKey];
         if (!root) {
             //a non-xml ECP response is usually the device explaining itself in plain text (for
             //example `ECP command not allowed in Limited mode.`), so carry that text in the error
@@ -2785,11 +2788,6 @@ export interface EcpResult {
     status: number | undefined;
     /** The raw response body (usually XML, empty for command routes like keypress) */
     body: string;
-    /**
-     * The XML response body parsed to a plain object (keyed by the XML root element), or undefined
-     * when the response had no XML body
-     */
-    json: Record<string, any> | undefined;
 }
 
 export interface QueryRegistryOptions extends BaseEcpOptions {


### PR DESCRIPTION
Closes #351.

SendEcpRequest is the raw ECP escape hatch; it now returns just { status, body } instead of also XML-parsing every response. The typed wrappers (getDeviceInfo, queryApps, exitApp, getEcpEnvelope, etc.) parse the body themselves via the private parseEcpXml, which now takes the EcpResult and builds error details with buildEcpHttpDetails. The raw transport can no longer throw UnparsableDeviceResponseError for a malformed body it was never asked to parse.